### PR TITLE
Add alphabetical order when reading files from conf.d

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-gpio (2.9.1) stable; urgency=medium
+
+  * Add alphabetical order when reading files
+
+ -- Ekaterina Volkova <ekaterina.volkova@wirenboard.ru>  Tue, 20 Sep 2022 16:13:35 +0300
+
 wb-mqtt-gpio (2.9.0) stable; urgency=medium
 
   * Switched to the C++17 standard

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 wb-mqtt-gpio (2.9.1) stable; urgency=medium
 
-  * Add alphabetical order when reading files
+  * Add alphabetical order when reading files from conf.d
 
  -- Ekaterina Volkova <ekaterina.volkova@wirenboard.ru>  Tue, 20 Sep 2022 16:13:35 +0300
 

--- a/file_utils.cpp
+++ b/file_utils.cpp
@@ -1,5 +1,6 @@
 #include "file_utils.h"
 #include <filesystem>
+#include <set>
 
 TNoDirError::TNoDirError(const std::string& msg) : std::runtime_error(msg) {}
 
@@ -26,9 +27,14 @@ void IterateDir(const std::string& dirName, std::function<bool(const std::string
 {
     try {
         const std::filesystem::path dirPath{dirName};
+        std::set<std::filesystem::path> sortedByPath;
 
-        for (const auto& entry: std::filesystem::directory_iterator(dirPath)) {
-            const auto filenameStr = entry.path().filename().string();
+        for (auto& entry: std::filesystem::directory_iterator(dirPath))
+            sortedByPath.insert(entry.path());
+
+        for (auto& filePath: sortedByPath) {
+            const auto filenameStr = filePath.filename().string();
+            LOG(Debug) << "filenameStr " << filenameStr;
             if (fn(filenameStr)) {
                 return;
             }

--- a/file_utils.cpp
+++ b/file_utils.cpp
@@ -34,7 +34,6 @@ void IterateDir(const std::string& dirName, std::function<bool(const std::string
 
         for (auto& filePath: sortedByPath) {
             const auto filenameStr = filePath.filename().string();
-            LOG(Debug) << "filenameStr " << filenameStr;
             if (fn(filenameStr)) {
                 return;
             }


### PR DESCRIPTION
При запросе чтения всех файлов, они предварительно помещаются в std::set, где автоматически сортируются по имени