### PR TITLE
Ignore unavailable GPIOs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-gpio (2.12.2) stable; urgency=medium
+
+  * Ignore unavailable GPIOs in config without crashing the service
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Fri, 11 Aug 2023 11:09:26 +0500
+
 wb-mqtt-gpio (2.12.1) stable; urgency=medium
 
   * Update README.md

--- a/generate-system-config.sh
+++ b/generate-system-config.sh
@@ -90,9 +90,10 @@ if [[ -d /sys/firmware/devicetree/base/wirenboard/gpios ]]; then
     echo "$GPIOSYSCONF" | jq '.channels|=sort_by(.order)|.channels|=map(del(.order))' > ${SYS_CONFFILE}
 
     custom_channels_filter=".definitions.gpio_channel.not.properties.name.enum=[$item_names]"
+    undefined_channels_filter=".definitions.undefined_channel.not.properties.name.enum=[$item_names]"
     system_inputs_filter=".definitions.system_input.properties.name.enum=[$input_names]"
     system_outputs_filter=".definitions.system_output.properties.name.enum=[$output_names]"
-    cat $SCHEMA_FILE | jq "$custom_channels_filter|$system_inputs_filter|$system_outputs_filter" > ${CONFED_SCHEMA_FILE}
+    cat $SCHEMA_FILE | jq "$undefined_channels_filter|$custom_channels_filter|$system_inputs_filter|$system_outputs_filter" > ${CONFED_SCHEMA_FILE}
 else
 	echo "/sys/firmware/devicetree/base/wirenboard/gpios is missing"
 fi

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -63,6 +63,11 @@ namespace
         cfg.PublishParameters.Set(maxUnchangedInterval);
 
         for (const auto& channel: channels) {
+            if (!channel.isMember("gpio")) {
+                LOG(Warn) << "Skip GPIO \"" << channel["name"].asString()
+                          << "\", it is unavailable or badly configured";
+                continue;
+            }
             TGpioLineConfig lineConfig;
             string path;
             if (channel["gpio"].isUInt()) {
@@ -233,9 +238,13 @@ void MakeJsonForConfed(const string& configFile, const string& systemConfigsDir,
         });
     } catch (const TNoDirError&) {
     }
+
+    // Add custom channels.
+    // They must contain "gpio" property,
+    // otherwise it is a config for unavailable channel and must be skipped
     for (const auto& ch: config["channels"]) {
         auto it = configuredChannels.find(ch["name"].asString());
-        if (it != configuredChannels.end()) {
+        if (it != configuredChannels.end() && ch.isMember("gpio")) {
             newChannels.append(ch);
         }
     }

--- a/wb-mqtt-gpio.schema.json
+++ b/wb-mqtt-gpio.schema.json
@@ -303,6 +303,21 @@
             "options": {
                 "disable_properties": true
             }
+        },
+        "undefined_channel": {
+            "type": "object",
+            "not": {
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "enum": []
+                    }
+                }
+            },
+            "properties": {
+                "gpio": { "not" : {} },
+                "direction": { "not" : {} }
+            }
         }
     },
     "properties": {
@@ -340,7 +355,8 @@
                 "oneOf": [
                     { "$ref": "#/definitions/gpio_channel" },
                     { "$ref": "#/definitions/system_input" },
-                    { "$ref": "#/definitions/system_output" }
+                    { "$ref": "#/definitions/system_output" },
+                    { "$ref": "#/definitions/undefined_channel" }
                 ]
             },
             "propertyOrder": 4,


### PR DESCRIPTION
If a module is removed from /etc/wb-hardware.conf, the service will unable to validate config with unavailable GPIOs. Ignore them during config loading and remove after editing with homeui

Задача с логами https://wirenboard.bitrix24.ru/company/personal/user/134/tasks/task/view/54804/