### PR TITLE
Feature/68632 i2c errors

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-gpio (2.12.7) stable; urgency=medium
+
+  * publish meta/error on gpiohandle_get_values ioctl
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Wed, 20 Dec 2023 01:12:19 +0300
+
 wb-mqtt-gpio (2.12.6) stable; urgency=medium
 
   * fix WB7 image build

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,7 @@ wb-mqtt-gpio (2.12.7) stable; urgency=medium
 
   * publish meta/error on gpiohandle_get_values ioctl
 
- -- Vladimir Romanov <v.romanov@wirenboard.ru>  Wed, 20 Dec 2023 01:12:19 +0300
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Tue, 26 Dec 2023 17:52:29 +0300
 
 wb-mqtt-gpio (2.12.6) stable; urgency=medium
 

--- a/generate-system-config.sh
+++ b/generate-system-config.sh
@@ -42,14 +42,12 @@ if [[ -d /sys/firmware/devicetree/base/wirenboard/gpios ]]; then
     item_names=""
     input_names=""
     output_names=""
-    disconnected=0
     for gpioname in  $(of_node_children "$node" | sort); do
         gpio="$(of_get_prop_gpio "$node/$gpioname" "io-gpios")"
         item_phandle=$(of_get_prop_ulong "$node/$gpioname" "io-gpios" | awk '{print $1}')
         item_chip_num=${PHANDLE_MAP[$item_phandle]}
         if [[ -z $item_chip_num ]]; then
-            (( disconnected = disconnected + 1 ))
-            gpiochip_path="disconnected_$disconnected"
+            gpiochip_path="disconnected_gpiochip"
         else
             gpiochip_path="/dev/gpiochip$item_chip_num"
         fi

--- a/generate-system-config.sh
+++ b/generate-system-config.sh
@@ -42,17 +42,24 @@ if [[ -d /sys/firmware/devicetree/base/wirenboard/gpios ]]; then
     item_names=""
     input_names=""
     output_names=""
+    disconnected=0
     for gpioname in  $(of_node_children "$node" | sort); do
         gpio="$(of_get_prop_gpio "$node/$gpioname" "io-gpios")"
         item_phandle=$(of_get_prop_ulong "$node/$gpioname" "io-gpios" | awk '{print $1}')
         item_chip_num=${PHANDLE_MAP[$item_phandle]}
+        if [[ -z $item_chip_num ]]; then
+            (( disconnected = disconnected + 1 ))
+            gpiochip_path="disconnected_$disconnected"
+        else
+            gpiochip_path="/dev/gpiochip$item_chip_num"
+        fi
         base=0
         pin=0
         of_gpio_unpack "$gpio" base pin
         direction=$(of_has_prop "$node/$gpioname" "input" && echo -n "input" || echo -n "output")
         ITEM="{ \
             \"name\" : \"$gpioname\", \
-            \"gpio\" : {\"chip\" : \"/dev/gpiochip$item_chip_num\", \"offset\" : $pin}, \
+            \"gpio\" : {\"chip\" : \"$gpiochip_path\", \"offset\" : $pin}, \
             \"direction\" : \"$direction\", \
             \"inverted\" : $(of_gpio_is_inverted "$gpio" && echo -n "true" || echo -n "false"), \
             \"initial_state\": $(of_has_prop "$node/$gpioname" "output-high" && echo -n "true" || echo -n "false") ,\

--- a/src/gpio_chip.cpp
+++ b/src/gpio_chip.cpp
@@ -23,7 +23,8 @@ TGpioChip::TGpioChip(const string& path): Fd(-1), Path(path)
         Name = Path;
         Label = "disconnected";
         LineCount = 0;
-        LOG(Error) << "Unable to open device path '" << Path << "'";
+        LOG(Error) << "Unable to open device path '" << Path << "'"
+                << ". Will treat all lines on it as disconnected";
         return;
     }
 
@@ -84,6 +85,11 @@ const string& TGpioChip::GetName() const
 const string& TGpioChip::GetLabel() const
 {
     return Label;
+}
+
+void TGpioChip::SetLabel(const string& label)
+{
+    Label = label;
 }
 
 const string& TGpioChip::GetPath() const

--- a/src/gpio_chip.cpp
+++ b/src/gpio_chip.cpp
@@ -20,7 +20,11 @@ TGpioChip::TGpioChip(const string& path): Fd(-1), Path(path)
 {
     Fd = open(Path.c_str(), O_RDWR | O_CLOEXEC);
     if (Fd < 0) {
-        wb_throw(TGpioDriverException, "unable to open device path '" + Path + "'");
+        Name = Path;
+        Label = "disconnected";
+        LineCount = 0;
+        LOG(Error) << "Unable to open device path '" << Path << "'";
+        return;
     }
 
     LOG(Debug) << "Open chip at " << Path;

--- a/src/gpio_chip.cpp
+++ b/src/gpio_chip.cpp
@@ -24,7 +24,7 @@ TGpioChip::TGpioChip(const string& path): Fd(-1), Path(path)
         Label = "disconnected";
         LineCount = 0;
         LOG(Error) << "Unable to open device path '" << Path << "'"
-                << ". Will treat all lines on it as disconnected";
+                   << ". Will treat all lines on it as disconnected";
         return;
     }
 

--- a/src/gpio_chip.h
+++ b/src/gpio_chip.h
@@ -3,7 +3,10 @@
 #include "config.h"
 #include "declarations.h"
 
+// #ifndef LINUX_GPIO
+// #define LINUX_GPIO
 #include <linux/gpio.h>
+// #endif
 
 class TGpioChip: public std::enable_shared_from_this<TGpioChip>
 {

--- a/src/gpio_chip.h
+++ b/src/gpio_chip.h
@@ -3,10 +3,7 @@
 #include "config.h"
 #include "declarations.h"
 
-// #ifndef LINUX_GPIO
-// #define LINUX_GPIO
 #include <linux/gpio.h>
-// #endif
 
 class TGpioChip: public std::enable_shared_from_this<TGpioChip>
 {

--- a/src/gpio_chip.h
+++ b/src/gpio_chip.h
@@ -20,6 +20,7 @@ public:
 
     const std::string& GetName() const;
     const std::string& GetLabel() const;
+    void SetLabel(const std::string&);
     const std::string& GetPath() const;
     std::string Describe() const;
     uint32_t GetLineCount() const;

--- a/src/gpio_chip_driver.cpp
+++ b/src/gpio_chip_driver.cpp
@@ -380,7 +380,14 @@ void TGpioChipDriver::AddDisconnectedLine(const PGpioLine& line)
 
 void TGpioChipDriver::ReInitOutput(const PGpioLine& line)
 {
+    /*
+        MCP's POR state is input => we need to init gpio-extender module as output on physicall reconnect.
+
+        "pinctrl_mcp23s08" kernel driver has internal cache => once init module as input
+        and then init as output to trigger needed i2c communication with mcp.
+    */
     assert(config->Direction == EGpioDirection::Output);
+    assert(line->AccessChip()->GetLabel() == "mcp23017");
 
     LOG(Warn) << "Reinit (request as input -> output) " << line->DescribeShort() << " to bring it back to life";
 

--- a/src/gpio_chip_driver.cpp
+++ b/src/gpio_chip_driver.cpp
@@ -505,12 +505,15 @@ void TGpioChipDriver::ReadLinesValues(const TGpioLines& lines)
     if (lines.empty()) {
         return;
     }
-    auto fd = lines.front()->GetFd();
+    const auto& line = lines.front();
+    auto fd = line->GetFd();
 
     gpiohandle_data data;
     if (ioctl(fd, GPIOHANDLE_GET_LINE_VALUES_IOCTL, &data) < 0) {
-        LOG(Error) << "GPIOHANDLE_GET_LINE_VALUES_IOCTL failed: " << strerror(errno);
-        wb_throw(TGpioDriverException, "unable to get line value");
+        LOG(Error) << line->DescribeShort() << " GPIOHANDLE_GET_LINE_VALUES_IOCTL failed: " << strerror(errno);
+        line->SetError(errno);
+    } else {
+        line->ClearError();
     }
 
     uint32_t i = 0;

--- a/src/gpio_chip_driver.cpp
+++ b/src/gpio_chip_driver.cpp
@@ -531,11 +531,13 @@ void TGpioChipDriver::PollLinesValues(const TGpioLines& lines)
             } else { /* in other case let line do idle actions */
                 line->Update();
             }
-        } else { /* for output just set value to cache: it will publish it if
+        } else { /* for output just set value to cache (if no error on gpioline): it will publish it if
                     changed */
-            if (line->DoesNeedReinit())
+            if (line->DoesNeedReinit()) {
                 ReInitOutput(line);
-            if (!line->GetError())
+                continue;
+            }
+            if (line->GetError() == 0)
                 line->SetCachedValue(newValue);
         }
     }

--- a/src/gpio_chip_driver.h
+++ b/src/gpio_chip_driver.h
@@ -17,7 +17,7 @@ class TGpioChipDriver
     TGpioTimersMap Timers;
     PGpioChip Chip;
     bool AddedToEpoll;
-    int FakeLineFd;
+    int DisconnectedLineFd;
 
 public:
     using TGpioLinesByOffsetMap = std::unordered_map<uint32_t, PGpioLine>;
@@ -38,12 +38,13 @@ public:
 
     void ForEachLine(const TGpioLineHandler&) const;
 
+    void AddDisconnectedLine(const PGpioLine&);
+
 private:
     bool ReleaseLineIfUsed(const PGpioLine&);
     bool TryListenLine(const PGpioLine&);
     bool InitOutput(const PGpioLine&, bool value);
     void ReInitOutput(const PGpioLine&);
-    void AddDisconnectedLine(const PGpioLine&);
     bool InitInputInterrupts(const PGpioLine&);
     bool InitLinesPolling(uint32_t flags, const TGpioLines& lines);
 

--- a/src/gpio_chip_driver.h
+++ b/src/gpio_chip_driver.h
@@ -41,7 +41,8 @@ public:
 private:
     bool ReleaseLineIfUsed(const PGpioLine&);
     bool TryListenLine(const PGpioLine&);
-    bool InitOutput(const PGpioLine&);
+    bool InitOutput(const PGpioLine&, bool value);
+    void ReInitOutput(const PGpioLine&);
     void AddDisconnectedLine(const PGpioLine&);
     bool InitInputInterrupts(const PGpioLine&);
     bool InitLinesPolling(uint32_t flags, const TGpioLines& lines);

--- a/src/gpio_chip_driver.h
+++ b/src/gpio_chip_driver.h
@@ -17,6 +17,7 @@ class TGpioChipDriver
     TGpioTimersMap Timers;
     PGpioChip Chip;
     bool AddedToEpoll;
+    int FakeLineFd;
 
 public:
     using TGpioLinesByOffsetMap = std::unordered_map<uint32_t, PGpioLine>;
@@ -41,6 +42,7 @@ private:
     bool ReleaseLineIfUsed(const PGpioLine&);
     bool TryListenLine(const PGpioLine&);
     bool InitOutput(const PGpioLine&);
+    void AddDisconnectedLine(const PGpioLine&);
     bool InitInputInterrupts(const PGpioLine&);
     bool InitLinesPolling(uint32_t flags, const TGpioLines& lines);
 

--- a/src/gpio_driver.cpp
+++ b/src/gpio_driver.cpp
@@ -182,8 +182,15 @@ TGpioDriver::TGpioDriver(const WBMQTT::PDeviceDriver& mqttDriver, const TGpioDri
             line->GetCounter()->SetInitialValues(value);
             valueForPublishing = line->GetCounter()->GetRoundedTotal();
         }
-        event.Control->GetDevice()->GetDriver()->AccessAsync(
-            [=](const PDriverTx& tx) { event.Control->SetRawValue(tx, valueForPublishing); });
+
+        auto lineError = line->GetError();
+        if (lineError) {
+            event.Control->GetDevice()->GetDriver()->AccessAsync(
+                [=](const PDriverTx& tx) { event.Control->UpdateValueAndError(tx, valueForPublishing, strerror(lineError)); });
+        } else {
+            event.Control->GetDevice()->GetDriver()->AccessAsync(
+                [=](const PDriverTx& tx) { event.Control->SetRawValue(tx, valueForPublishing); });
+        }
     });
 }
 

--- a/src/gpio_driver.cpp
+++ b/src/gpio_driver.cpp
@@ -185,8 +185,9 @@ TGpioDriver::TGpioDriver(const WBMQTT::PDeviceDriver& mqttDriver, const TGpioDri
 
         auto lineError = line->GetError();
         if (lineError) {
-            event.Control->GetDevice()->GetDriver()->AccessAsync(
-                [=](const PDriverTx& tx) { event.Control->UpdateValueAndError(tx, valueForPublishing, strerror(lineError)); });
+            event.Control->GetDevice()->GetDriver()->AccessAsync([=](const PDriverTx& tx) {
+                event.Control->UpdateValueAndError(tx, valueForPublishing, strerror(lineError));
+            });
         } else {
             event.Control->GetDevice()->GetDriver()->AccessAsync(
                 [=](const PDriverTx& tx) { event.Control->SetRawValue(tx, valueForPublishing); });
@@ -212,66 +213,66 @@ void TGpioDriver::Start()
         Active = true;
     }
 
-    Worker = WBMQTT::MakeThread("GPIO worker", {[this] {
-                                    LOG(Info) << "Started";
+    Worker =
+        WBMQTT::MakeThread("GPIO worker", {[this] {
+                               LOG(Info) << "Started";
 
-                                    int epfd = epoll_create(1); // creating epoll for Interrupts
-                                    struct epoll_event events[EPOLL_EVENT_COUNT]
-                                    {};
+                               int epfd = epoll_create(1); // creating epoll for Interrupts
+                               struct epoll_event events[EPOLL_EVENT_COUNT]
+                               {};
 
-                                    WB_SCOPE_EXIT(close(epfd);)
+                               WB_SCOPE_EXIT(close(epfd);)
 
-                                    for (const auto& chipDriver: ChipDrivers) {
-                                        chipDriver->AddToEpoll(epfd);
-                                    }
+                               for (const auto& chipDriver: ChipDrivers) {
+                                   chipDriver->AddToEpoll(epfd);
+                               }
 
-                                    while (Active) {
-                                        bool isHandled = false;
-                                        if (int count = epoll_wait(epfd, events, EPOLL_EVENT_COUNT, EPOLL_TIMEOUT_MS)) {
-                                            TInterruptionContext ctx{count, events};
-                                            for (const auto& chipDriver: ChipDrivers) {
-                                                isHandled |= chipDriver->HandleInterrupt(ctx);
-                                            }
-                                        } else {
-                                            for (const auto& chipDriver: ChipDrivers) {
-                                                isHandled |= chipDriver->PollLines();
-                                            }
-                                        }
+                               while (Active) {
+                                   bool isHandled = false;
+                                   if (int count = epoll_wait(epfd, events, EPOLL_EVENT_COUNT, EPOLL_TIMEOUT_MS)) {
+                                       TInterruptionContext ctx{count, events};
+                                       for (const auto& chipDriver: ChipDrivers) {
+                                           isHandled |= chipDriver->HandleInterrupt(ctx);
+                                       }
+                                   } else {
+                                       for (const auto& chipDriver: ChipDrivers) {
+                                           isHandled |= chipDriver->PollLines();
+                                       }
+                                   }
 
-                                        if (!isHandled) {
-                                            continue;
-                                        }
+                                   if (!isHandled) {
+                                       continue;
+                                   }
 
-                                        auto tx = MqttDriver->BeginTx();
-                                        auto device = tx->GetDevice(Name);
+                                   auto tx = MqttDriver->BeginTx();
+                                   auto device = tx->GetDevice(Name);
 
-                                        for (const auto& chipDriver: ChipDrivers) {
-                                            FOR_EACH_LINE(chipDriver, line)
-                                            {
-                                                const auto err = line->GetError();
-                                                if (err) {
-                                                    device->GetControl(line->GetConfig()->Name)
-                                                        ->SetError(tx, strerror(err));
-                                                } else {
-                                                    if (const auto& counter = line->GetCounter()) {
-                                                        for (const auto& idValue:
-                                                            counter->GetIdsAndValues(line->GetConfig()->Name)) {
-                                                            const auto& id = idValue.first;
-                                                            const auto value = idValue.second;
+                                   for (const auto& chipDriver: ChipDrivers) {
+                                       FOR_EACH_LINE(chipDriver, line)
+                                       {
+                                           const auto err = line->GetError();
+                                           if (err) {
+                                               device->GetControl(line->GetConfig()->Name)->SetError(tx, strerror(err));
+                                           } else {
+                                               if (const auto& counter = line->GetCounter()) {
+                                                   for (const auto& idValue:
+                                                        counter->GetIdsAndValues(line->GetConfig()->Name)) {
+                                                       const auto& id = idValue.first;
+                                                       const auto value = idValue.second;
 
-                                                            device->GetControl(id)->SetRawValue(tx, value);
-                                                        }
-                                                    } else {
-                                                        device->GetControl(line->GetConfig()->Name)
-                                                            ->SetValue(tx, static_cast<bool>(line->GetValue()));
-                                                    }
-                                                }
-                                            });
-                                        }
-                                    }
+                                                       device->GetControl(id)->SetRawValue(tx, value);
+                                                   }
+                                               } else {
+                                                   device->GetControl(line->GetConfig()->Name)
+                                                       ->SetValue(tx, static_cast<bool>(line->GetValue()));
+                                               }
+                                           }
+                                       });
+                                   }
+                               }
 
-                                    LOG(Info) << "Stopped";
-                                }});
+                               LOG(Info) << "Stopped";
+                           }});
 }
 
 void TGpioDriver::Stop()

--- a/src/gpio_driver.cpp
+++ b/src/gpio_driver.cpp
@@ -241,17 +241,23 @@ void TGpioDriver::Start()
                                         for (const auto& chipDriver: ChipDrivers) {
                                             FOR_EACH_LINE(chipDriver, line)
                                             {
-                                                if (const auto& counter = line->GetCounter()) {
-                                                    for (const auto& idValue:
-                                                         counter->GetIdsAndValues(line->GetConfig()->Name)) {
-                                                        const auto& id = idValue.first;
-                                                        const auto value = idValue.second;
-
-                                                        device->GetControl(id)->SetRawValue(tx, value);
-                                                    }
-                                                } else {
+                                                const auto err = line->GetError();
+                                                if (err) {
                                                     device->GetControl(line->GetConfig()->Name)
-                                                        ->SetValue(tx, static_cast<bool>(line->GetValue()));
+                                                        ->SetError(tx, strerror(err));
+                                                } else {
+                                                    if (const auto& counter = line->GetCounter()) {
+                                                        for (const auto& idValue:
+                                                            counter->GetIdsAndValues(line->GetConfig()->Name)) {
+                                                            const auto& id = idValue.first;
+                                                            const auto value = idValue.second;
+
+                                                            device->GetControl(id)->SetRawValue(tx, value);
+                                                        }
+                                                    } else {
+                                                        device->GetControl(line->GetConfig()->Name)
+                                                            ->SetValue(tx, static_cast<bool>(line->GetValue()));
+                                                    }
                                                 }
                                             });
                                         }

--- a/src/gpio_line.cpp
+++ b/src/gpio_line.cpp
@@ -85,8 +85,7 @@ std::string TGpioLine::DescribeShort() const
     std::string chipNum;
     try {
         chipNum = to_string(AccessChip()->GetNumber());
-    }
-    catch (const TGpioDriverException& e) {
+    } catch (const TGpioDriverException& e) {
         chipNum = "disconnected";
     }
 
@@ -209,8 +208,8 @@ struct gpiohandle_data TGpioLine::FdGet()
         SetError(errno);
     } else {
         if (GetError() != 0) {
-            LOG(Warn) << DescribeShort() << " is connected again. Clearing error '"
-                        << strerror(GetError()) << "' on it";
+            LOG(Warn) << DescribeShort() << " is connected again. Clearing error '" << strerror(GetError())
+                      << "' on it";
             ClearError();
         }
     }
@@ -226,8 +225,9 @@ void TGpioLine::FdSet(uint8_t value)
     data.values[0] = value;
 
     if (ioctl(Fd, GPIOHANDLE_SET_LINE_VALUES_IOCTL, &data) < 0) {
-        LOG(Error) "Set " << to_string((int)value) << " to: " << DescribeShort()
-                    << " GPIOHANDLE_SET_LINE_VALUES_IOCTL failed: " << strerror(errno);
+        LOG(Error)
+        "Set " << to_string((int)value) << " to: " << DescribeShort()
+               << " GPIOHANDLE_SET_LINE_VALUES_IOCTL failed: " << strerror(errno);
         SetError(errno);
     }
 }
@@ -242,8 +242,8 @@ void TGpioLine::SetValue(uint8_t value)
         FdSet(value);
         SetCachedValue(value);
     } else {
-        LOG(Warn) << DescribeShort() << " has error: " << strerror(error)
-                << "; Will not set value " << to_string(value);
+        LOG(Warn) << DescribeShort() << " has error: " << strerror(error) << "; Will not set value "
+                  << to_string(value);
     }
 }
 

--- a/src/gpio_line.cpp
+++ b/src/gpio_line.cpp
@@ -201,7 +201,8 @@ struct gpiohandle_data TGpioLine::FdGet()
         SetError(errno);
     } else {
         if (GetError() != 0) {
-            LOG(Debug) << "Clearing error on " << DescribeShort();
+            LOG(Warn) << DescribeShort() << " is connected again. Clearing error '"
+                        << strerror(GetError()) << "' on it";
             ClearError();
         }
     }
@@ -229,11 +230,11 @@ void TGpioLine::SetValue(uint8_t value)
     assert(IsHandled());
 
     auto error = GetError();
-    if (!error) {
+    if (error == 0) {
         FdSet(value);
         SetCachedValue(value);
     } else {
-        LOG(Error) << DescribeShort() << " has error: " << strerror(error)
+        LOG(Warn) << DescribeShort() << " has error: " << strerror(error)
                 << "; Will not set value " << to_string(value);
     }
 }

--- a/src/gpio_line.cpp
+++ b/src/gpio_line.cpp
@@ -179,7 +179,7 @@ uint8_t TGpioLine::GetValueUnfiltered() const
     return ValueUnfiltered.Get();
 }
 
-gpiohandle_data TGpioLine::ReadFd() const
+struct gpiohandle_data TGpioLine::ReadFd()
 {
     gpiohandle_data data;
     if (ioctl(GetFd(), GPIOHANDLE_GET_LINE_VALUES_IOCTL, &data) < 0) {
@@ -241,9 +241,9 @@ void TGpioLine::SetFd(int fd)
     UpdateInfo();
 }
 
-void TGpioLine::SetError(int errno)
+void TGpioLine::SetError(int err)
 {
-    Error = errno;
+    Error = err;
 }
 
 void TGpioLine::ClearError()

--- a/src/gpio_line.cpp
+++ b/src/gpio_line.cpp
@@ -82,8 +82,16 @@ void TGpioLine::UpdateInfo()
 
 std::string TGpioLine::DescribeShort() const
 {
+    std::string chipNum;
+    try {
+        chipNum = to_string(AccessChip()->GetNumber());
+    }
+    catch (const TGpioDriverException& e) {
+        chipNum = "disconnected";
+    }
+
     ostringstream ss;
-    ss << "GPIO line " << AccessChip()->GetNumber() << ":" << Offset;
+    ss << "GPIO line " << chipNum << ":" << Offset;
     if (Config) {
         ss << " (" << Config->Name << ")";
     }

--- a/src/gpio_line.cpp
+++ b/src/gpio_line.cpp
@@ -158,7 +158,7 @@ bool TGpioLine::DoesNeedReinit() const
     return NeedReinit;
 }
 
-void TGpioLine::MakeOutput()
+void TGpioLine::TreatAsOutput()
 {
     Flags |= GPIOLINE_FLAG_IS_OUT;
 }

--- a/src/gpio_line.cpp
+++ b/src/gpio_line.cpp
@@ -246,9 +246,14 @@ void TGpioLine::SetError(int err)
     Error = err;
 }
 
+int TGpioLine::GetError() const
+{
+    return Error;
+}
+
 void TGpioLine::ClearError()
 {
-    Error = 0;
+    SetError(0);
 }
 
 int TGpioLine::GetFd() const

--- a/src/gpio_line.h
+++ b/src/gpio_line.h
@@ -46,7 +46,7 @@ public:
     bool IsOpenSource() const;
     uint8_t GetValue() const;
     uint8_t GetValueUnfiltered() const;
-    gpiohandle_data ReadFd() const;
+    struct gpiohandle_data ReadFd();
     void SetValue(uint8_t);
     void SetCachedValue(uint8_t);
     void SetCachedValueUnfiltered(uint8_t);

--- a/src/gpio_line.h
+++ b/src/gpio_line.h
@@ -16,6 +16,7 @@ class TGpioLine
     int Fd;
     int TimerFd;
     int Error;
+    bool NeedReinit;
     std::string Name;
     std::string Consumer;
 
@@ -40,6 +41,8 @@ public:
     uint32_t GetOffset() const;
     uint32_t GetFlags() const;
     bool IsOutput() const;
+    bool DoesNeedReinit() const;
+    void SetDoesNeedReinit(bool);
     void MakeOutput();
     bool IsActiveLow() const;
     bool IsUsed() const;
@@ -47,7 +50,8 @@ public:
     bool IsOpenSource() const;
     uint8_t GetValue() const;
     uint8_t GetValueUnfiltered() const;
-    struct gpiohandle_data ReadFd();
+    struct gpiohandle_data FdGet();
+    void FdSet(uint8_t);
     void SetValue(uint8_t);
     void SetCachedValue(uint8_t);
     void SetCachedValueUnfiltered(uint8_t);

--- a/src/gpio_line.h
+++ b/src/gpio_line.h
@@ -15,6 +15,7 @@ class TGpioLine
     uint32_t Flags;
     int Fd;
     int TimerFd;
+    int Error;
     std::string Name;
     std::string Consumer;
 
@@ -45,9 +46,12 @@ public:
     bool IsOpenSource() const;
     uint8_t GetValue() const;
     uint8_t GetValueUnfiltered() const;
+    gpiohandle_data ReadFd() const;
     void SetValue(uint8_t);
     void SetCachedValue(uint8_t);
     void SetCachedValueUnfiltered(uint8_t);
+    void SetError(int);
+    void ClearError();
     PGpioChip AccessChip() const;
     bool IsHandled() const;
     void SetFd(int);

--- a/src/gpio_line.h
+++ b/src/gpio_line.h
@@ -40,6 +40,7 @@ public:
     uint32_t GetOffset() const;
     uint32_t GetFlags() const;
     bool IsOutput() const;
+    void MakeOutput();
     bool IsActiveLow() const;
     bool IsUsed() const;
     bool IsOpenDrain() const;

--- a/src/gpio_line.h
+++ b/src/gpio_line.h
@@ -51,6 +51,7 @@ public:
     void SetCachedValue(uint8_t);
     void SetCachedValueUnfiltered(uint8_t);
     void SetError(int);
+    int GetError() const;
     void ClearError();
     PGpioChip AccessChip() const;
     bool IsHandled() const;

--- a/src/gpio_line.h
+++ b/src/gpio_line.h
@@ -43,7 +43,7 @@ public:
     bool IsOutput() const;
     bool DoesNeedReinit() const;
     void SetDoesNeedReinit(bool);
-    void MakeOutput();
+    void TreatAsOutput();
     bool IsActiveLow() const;
     bool IsUsed() const;
     bool IsOpenDrain() const;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -177,7 +177,14 @@ namespace Utils
 
     uint32_t GpioPathToChipNumber(const string& path)
     {
-        return stoul(path.substr(13));
+        try {
+            return stoul(path.substr(13));
+        }
+        catch (const std::invalid_argument& ex) {
+        }
+        catch (const std::out_of_range& ex) {
+        }
+        wb_throw(TGpioDriverException, "unable to get gpiochip number from '" + path + "'");
     }
 
     uint32_t GpioChipLabelToNumber(const string& label)

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -179,10 +179,8 @@ namespace Utils
     {
         try {
             return stoul(path.substr(13));
-        }
-        catch (const std::invalid_argument& ex) {
-        }
-        catch (const std::out_of_range& ex) {
+        } catch (const std::invalid_argument& ex) {
+        } catch (const std::out_of_range& ex) {
         }
         wb_throw(TGpioDriverException, "unable to get gpiochip number from '" + path + "'");
     }

--- a/test/gpiochip_disconnected.test.cpp
+++ b/test/gpiochip_disconnected.test.cpp
@@ -5,7 +5,8 @@
 #include "types.h"
 #include <gtest/gtest.h>
 
-class TDisconnectedChipTest: public testing::Test{};
+class TDisconnectedChipTest: public testing::Test
+{};
 
 TEST_F(TDisconnectedChipTest, init_disconnected_chip)
 {
@@ -14,13 +15,12 @@ TEST_F(TDisconnectedChipTest, init_disconnected_chip)
     ASSERT_EQ(chip->GetName(), dummyPath);
     ASSERT_EQ(chip->GetLabel(), "disconnected");
     ASSERT_EQ(chip->GetLineCount(), 0);
-    EXPECT_THROW(chip->GetNumber(), TGpioDriverException)
 }
 
 class TGpioChipDisconnectedTest: public testing::Test
 {
 protected:
-    TGpioChipConfig fakeGpioChipConfig {"disconnected_1"};
+    TGpioChipConfig fakeGpioChipConfig{"disconnected_1"};
     TGpioLineConfig fakeGpioLineConfig;
 
     void SetUp()
@@ -46,4 +46,3 @@ TEST_F(TGpioChipDisconnectedTest, add_disconnected_line)
     fakeGpioChipDriver->AddDisconnectedLine(fakeGpioLine);
     ASSERT_EQ(fakeGpioLine->GetFd(), -3);
 }
-

--- a/test/gpiochip_disconnected.test.cpp
+++ b/test/gpiochip_disconnected.test.cpp
@@ -1,0 +1,48 @@
+#include "declarations.h"
+#include "gpio_chip.h"
+#include "gpio_chip_driver.h"
+#include "gpio_line.h"
+#include "types.h"
+#include <gtest/gtest.h>
+
+class TDisconnectedChipTest: public testing::Test{};
+
+TEST_F(TDisconnectedChipTest, init_disconnected_chip)
+{
+    auto dummyPath = "/dev/DUMMY_PATH";
+    auto chip = std::make_shared<TGpioChip>(dummyPath);
+    ASSERT_EQ(chip->GetName(), dummyPath);
+    ASSERT_EQ(chip->GetLabel(), "disconnected");
+    ASSERT_EQ(chip->GetLineCount(), 0);
+}
+
+class TGpioChipDisconnectedTest: public testing::Test
+{
+protected:
+    TGpioChipConfig fakeGpioChipConfig {"disconnected_1"};
+    TGpioLineConfig fakeGpioLineConfig;
+
+    void SetUp()
+    {
+        fakeGpioLineConfig.DebounceTimeout = std::chrono::microseconds(0);
+        fakeGpioLineConfig.Offset = 0;
+        fakeGpioLineConfig.Name = "testline";
+        fakeGpioLineConfig.Direction = EGpioDirection::Input;
+
+        fakeGpioChipConfig.Lines.push_back(fakeGpioLineConfig);
+    }
+};
+
+TEST_F(TGpioChipDisconnectedTest, add_disconnected_line)
+{
+    const auto chip = std::make_shared<TGpioChip>("disconnected_1");
+    auto fakeGpioChipDriver = std::make_shared<TGpioChipDriver>(fakeGpioChipConfig);
+    auto fakeGpioLine = std::make_shared<TGpioLine>(chip, fakeGpioLineConfig);
+    fakeGpioLine->SetFd(0);
+    ASSERT_EQ(fakeGpioLine->GetFd(), 0);
+    fakeGpioChipDriver->AddDisconnectedLine(fakeGpioLine);
+    ASSERT_EQ(fakeGpioLine->GetFd(), -2);
+    fakeGpioChipDriver->AddDisconnectedLine(fakeGpioLine);
+    ASSERT_EQ(fakeGpioLine->GetFd(), -3);
+}
+

--- a/test/gpiochip_disconnected.test.cpp
+++ b/test/gpiochip_disconnected.test.cpp
@@ -14,6 +14,7 @@ TEST_F(TDisconnectedChipTest, init_disconnected_chip)
     ASSERT_EQ(chip->GetName(), dummyPath);
     ASSERT_EQ(chip->GetLabel(), "disconnected");
     ASSERT_EQ(chip->GetLineCount(), 0);
+    EXPECT_THROW(chip->GetNumber(), TGpioDriverException)
 }
 
 class TGpioChipDisconnectedTest: public testing::Test

--- a/test/gpioline_error.test.cpp
+++ b/test/gpioline_error.test.cpp
@@ -34,3 +34,24 @@ TEST_F(TLineErrorTest, set_clear_error)
     fakeGpioLine->ClearError();
     ASSERT_EQ(fakeGpioLine->GetError(), 0);
 }
+
+TEST_F(TLineErrorTest, treat_as_output)
+{
+    const auto fakeGpioLine = std::make_shared<TGpioLine>(fakeGpioLineConfig);
+    ASSERT_FALSE(fakeGpioLine->IsOutput());
+    fakeGpioLine->TreatAsOutput();
+    ASSERT_TRUE(fakeGpioLine->IsOutput());
+}
+
+TEST_F(TLineErrorTest, does_need_reinit)
+{
+    const auto chip = std::make_shared<TGpioChip>("disconnected_1");
+    const auto fakeGpioLine = std::make_shared<TGpioLine>(chip, fakeGpioLineConfig);
+
+    fakeGpioLine->TreatAsOutput();
+    fakeGpioLine->AccessChip()->SetLabel("mcp23017");
+
+    ASSERT_FALSE(fakeGpioLine->DoesNeedReinit());
+    fakeGpioLine->ClearError();
+    ASSERT_TRUE(fakeGpioLine->DoesNeedReinit());
+}

--- a/test/gpioline_error.test.cpp
+++ b/test/gpioline_error.test.cpp
@@ -1,0 +1,36 @@
+#include "declarations.h"
+#include "gpio_chip.h"
+#include "gpio_line.h"
+#include "types.h"
+#include <gtest/gtest.h>
+
+class TLineErrorTest: public testing::Test
+{
+protected:
+    TGpioLineConfig fakeGpioLineConfig;
+
+    void SetUp()
+    {
+        int debounceTimeoutUs = 0;
+
+        fakeGpioLineConfig.DebounceTimeout = std::chrono::microseconds(debounceTimeoutUs);
+        fakeGpioLineConfig.Offset = 0;
+        fakeGpioLineConfig.Name = "testline";
+    }
+};
+
+TEST_F(TLineErrorTest, initial_error)
+{
+    const auto fakeGpioLine = std::make_shared<TGpioLine>(fakeGpioLineConfig);
+    ASSERT_EQ(fakeGpioLine->GetError(), 0);
+}
+
+TEST_F(TLineErrorTest, set_clear_error)
+{
+    int err = -10;
+    const auto fakeGpioLine = std::make_shared<TGpioLine>(fakeGpioLineConfig);
+    fakeGpioLine->SetError(err);
+    ASSERT_EQ(fakeGpioLine->GetError(), err);
+    fakeGpioLine->ClearError();
+    ASSERT_EQ(fakeGpioLine->GetError(), 0);
+}


### PR DESCRIPTION
Теперь mqtt-гпиво умеет светить красненьким, если боковые модули отвалились

https://github.com/wirenboard/wb-mqtt-gpio/assets/25829054/cadb809c-c11e-4d31-89ec-aca3d36e8211

Концептуально - ядро не убирает /dev/gpiochip* у отвалившихся модулей => с [патчем](https://github.com/wirenboard/linux/pull/169) - мы можем отследить отваливание модулей хотя бы по неудачным ioctl

Кейсы:
1) модуль физически не вставлен => выставляем в хвконфе => горит всё время красненьким, пока не переткнуть его в хвконфе (на самом деле, надо modprobe -r pinctrl_mcp23s08_i2c; modprobe pinctrl_mcp23s08_i2c). Т.к. ядерный драйвер не подозревает о том, что mcp23xx может отключаться в процессе

2) модуль физически вставлен => выставляем в хвконфе => физически вытаскиваем-вставляем - горит красным и чинится; см видео

3) модуль физически не вставлен => выставляем в хвконфе => физически вставляем после - не сделано. Ядро не умеет в такое, а как лучше обойти снаружи - мы не решили => отложили на потом