### PR TITLE
Feature/72426 counter current

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 wb-mqtt-gpio (2.13.1) stable; urgency=medium
 
   * gpio_counter: fix "current" counting
+  * gpio_counter: fix "both" edge option, add "autodetect" option
 
  -- Vladimir Romanov <v.romanov@wirenboard.ru>  Mon, 17 Mar 2024 09:12:45 +0300
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-gpio (2.13.1) stable; urgency=medium
+
+  * gpio_counter: fix "current" counting
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Mon, 17 Mar 2024 09:12:45 +0300
+
 wb-mqtt-gpio (2.13.0) stable; urgency=medium
 
   * Add detection of disconnected EXT* modules

--- a/src/config.h
+++ b/src/config.h
@@ -19,7 +19,7 @@ struct TGpioLineConfig
     bool IsActiveLow = false;
     std::string Name;
     EGpioDirection Direction = EGpioDirection::Output;
-    EGpioEdge InterruptEdge = EGpioEdge::BOTH;
+    EGpioEdge InterruptEdge = EGpioEdge::AUTO;
     std::string Type;
     float Multiplier = 1.0;
     int DecimalPlacesTotal = -1;

--- a/src/gpio_chip_driver.cpp
+++ b/src/gpio_chip_driver.cpp
@@ -117,6 +117,9 @@ TGpioChipDriver::TGpioChipDriver(const TGpioChipConfig& config): AddedToEpoll(fa
     ReadInputValues();
 }
 
+TGpioChipDriver::TGpioChipDriver(): AddedToEpoll(false)
+{}
+
 TGpioChipDriver::~TGpioChipDriver()
 {
     for (const auto& fdLines: Lines) {
@@ -365,12 +368,22 @@ bool TGpioChipDriver::TryListenLine(const PGpioLine& line)
 
     req.eventflags = 0;
 
-    if (config->InterruptEdge == EGpioEdge::RISING)
-        req.eventflags |= GPIOEVENT_REQUEST_RISING_EDGE;
-    else if (config->InterruptEdge == EGpioEdge::FALLING)
-        req.eventflags |= GPIOEVENT_REQUEST_FALLING_EDGE;
-    else if (config->InterruptEdge == EGpioEdge::BOTH)
-        req.eventflags |= GPIOEVENT_REQUEST_BOTH_EDGES;
+    switch (config->InterruptEdge) {
+        case EGpioEdge::RISING:
+            req.eventflags |= GPIOEVENT_REQUEST_RISING_EDGE;
+            break;
+        case EGpioEdge::FALLING:
+            req.eventflags |= GPIOEVENT_REQUEST_FALLING_EDGE;
+            break;
+        case EGpioEdge::BOTH:
+            req.eventflags |= GPIOEVENT_REQUEST_BOTH_EDGES;
+            break;
+        case EGpioEdge::AUTO:
+            req.eventflags |= GPIOEVENT_REQUEST_BOTH_EDGES;
+            break;
+        default:
+            wb_throw(TGpioDriverException, "Unknown interrupt edge in config");
+    }
 
     errno = 0;
     if (ioctl(Chip->GetFd(), GPIO_GET_LINEEVENT_IOCTL, &req) < 0) {
@@ -606,7 +619,7 @@ void TGpioChipDriver::AutoDetectInterruptEdges()
     static auto doesNeedAutoDetect = [](const PGpioLine& line) {
         if (line->IsHandled() && !line->IsOutput()) {
             if (const auto& counter = line->GetCounter()) {
-                return counter->GetInterruptEdge() == EGpioEdge::BOTH;
+                return counter->GetInterruptEdge() == EGpioEdge::AUTO;
             }
         }
 

--- a/src/gpio_chip_driver.h
+++ b/src/gpio_chip_driver.h
@@ -16,7 +16,6 @@ class TGpioChipDriver
     using TGpioTimersMap = std::unordered_map<int, TGpioLines>;
     using TGpioLinesByOffsetMap = std::unordered_map<uint32_t, PGpioLine>;
 
-    TGpioLinesMap Lines;
     TGpioLinesByOffsetMap InitiallyDisconnectedLines;
     TGpioTimersMap Timers;
     PGpioChip Chip;
@@ -26,6 +25,7 @@ public:
     using TGpioLineHandler = std::function<void(const PGpioLine&)>;
 
     explicit TGpioChipDriver(const TGpioChipConfig&);
+    explicit TGpioChipDriver();
     ~TGpioChipDriver();
 
     TGpioLinesByOffsetMap MapLinesByOffset() const;
@@ -50,14 +50,17 @@ private:
     bool InitLinesPolling(uint32_t flags, const TGpioLines& lines);
 
     void PollLinesValues(const TGpioLines&);
-    void ReadLinesValues(const TGpioLines&);
+    virtual void ReadLinesValues(const TGpioLines&);
 
-    void ReListenLine(PGpioLine);
-    void AutoDetectInterruptEdges();
+    virtual void ReListenLine(PGpioLine);
     void ReadInputValues();
 
     bool HandleTimerInterrupt(const PGpioLine&);
     bool HandleGpioInterrupt(const PGpioLine& line, const TInterruptionContext& ctx);
+
+protected:
+    TGpioLinesMap Lines;
+    void AutoDetectInterruptEdges();
 };
 
 #define FOR_EACH_LINE(driver, line) driver->ForEachLine([&](const PGpioLine & line)

--- a/src/gpio_counter.cpp
+++ b/src/gpio_counter.cpp
@@ -39,7 +39,7 @@ TGpioCounter::TGpioCounter(const TGpioLineConfig& config)
     } else if (config.Type == WATER_METER) {
         TotalType = "water_consumption";
         CurrentType = "water_flow";
-        ConvertingMultiplier = 1.0 / 3600; // convert 1/h to 1/s
+        ConvertingMultiplier = 1.0; // 1/h
         DecimalPlacesCurrent = (DecimalPlacesCurrent == -1) ? 3 : DecimalPlacesCurrent;
         DecimalPlacesTotal = (DecimalPlacesTotal == -1) ? 2 : DecimalPlacesTotal;
     } else {

--- a/src/gpio_line.h
+++ b/src/gpio_line.h
@@ -20,6 +20,7 @@ class TGpioLine
     std::string Consumer;
 
     TTimePoint PreviousInterruptionTimePoint;
+    TTimePoint PreviousStableValAcquiredTimePoint;
 
     TValue<uint8_t> Value;
     TValue<uint8_t> ValueUnfiltered;

--- a/src/gpio_line.h
+++ b/src/gpio_line.h
@@ -33,14 +33,14 @@ public:
     ~TGpioLine();
 
     void UpdateInfo();
-    std::string DescribeShort() const;
+    virtual std::string DescribeShort() const;
     std::string Describe() const;
     std::string DescribeVerbose() const;
     const std::string& GetName() const;
     const std::string& GetConsumer() const;
     uint32_t GetOffset() const;
     uint32_t GetFlags() const;
-    bool IsOutput() const;
+    virtual bool IsOutput() const;
     bool IsActiveLow() const;
     bool IsUsed() const;
     bool IsOpenDrain() const;
@@ -53,7 +53,7 @@ public:
     const std::string& GetError() const;
     void SetError(const std::string&);
     PGpioChip AccessChip() const;
-    bool IsHandled() const;
+    virtual bool IsHandled() const;
     void SetFd(int);
     int GetFd() const;
     void SetTimerFd(int);

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -28,6 +28,8 @@ string GpioEdgeToString(EGpioEdge edge)
             return "falling";
         case EGpioEdge::BOTH:
             return "both";
+        case EGpioEdge::AUTO:
+            return "auto";
         default:
             return "<unknown (" + to_string((int)edge) + ")>";
     }

--- a/src/types.h
+++ b/src/types.h
@@ -6,7 +6,8 @@ enum class EGpioEdge : uint8_t
 {
     RISING,
     FALLING,
-    BOTH
+    BOTH,
+    AUTO
 };
 
 void EnumerateGpioEdge(const std::string&, EGpioEdge&);

--- a/test/debounce.test.cpp
+++ b/test/debounce.test.cpp
@@ -21,6 +21,7 @@ protected:
         fakeGpioLineConfig.Offset = 0;
         fakeGpioLineConfig.Name = "testline";
         fakeGpioLineConfig.Type = "water_meter";
+        fakeGpioLineConfig.InterruptEdge = EGpioEdge::BOTH;
     }
 };
 

--- a/test/debounce.test.cpp
+++ b/test/debounce.test.cpp
@@ -80,8 +80,7 @@ TEST_F(TDebounceTest, count_debounce_not_firing)
     HandleGpioEvent(fakeGpioLine, 1, now);
     ASSERT_TRUE(fakeGpioLine->UpdateIfStable(now + std::chrono::microseconds(debounceTimeoutUs + 1)));
     HandleGpioEvent(fakeGpioLine, 0, (now + std::chrono::microseconds(betweenEventsUs)));
-    ASSERT_TRUE(fakeGpioLine->UpdateIfStable(now + std::chrono::microseconds(betweenEventsUs) +
-                                             std::chrono::microseconds(debounceTimeoutUs + 1)));
+    ASSERT_TRUE(fakeGpioLine->UpdateIfStable(now + std::chrono::microseconds(betweenEventsUs + debounceTimeoutUs + 1)));
 
     ASSERT_EQ(fakeGpioLine->GetCounter()->GetCurrent(), 3600);
     ASSERT_EQ(fakeGpioLine->GetCounter()->GetTotal(), 2);
@@ -100,8 +99,8 @@ TEST_F(TDebounceTest, count_debounce_is_firing)
     HandleGpioEvent(fakeGpioLine, 1, now);
     ASSERT_FALSE(fakeGpioLine->UpdateIfStable(now + std::chrono::microseconds(debounceTimeoutUs - 1)));
     HandleGpioEvent(fakeGpioLine, 0, now + std::chrono::microseconds(betweenEventsUs));
-    ASSERT_FALSE(fakeGpioLine->UpdateIfStable(now + std::chrono::microseconds(betweenEventsUs) +
-                                              std::chrono::microseconds(debounceTimeoutUs - 1)));
+    ASSERT_FALSE(
+        fakeGpioLine->UpdateIfStable(now + std::chrono::microseconds(betweenEventsUs + debounceTimeoutUs - 1)));
 
     ASSERT_EQ(fakeGpioLine->GetCounter()->GetTotal(), 0);
     ASSERT_EQ(fakeGpioLine->GetCounter()->GetCurrent(), 0);

--- a/test/gpiocounter.test.cpp
+++ b/test/gpiocounter.test.cpp
@@ -1,0 +1,123 @@
+#include "config.h"
+#include "declarations.h"
+#include "gpio_chip_driver.h"
+#include "gpio_counter.h"
+#include "gpio_line.h"
+#include "types.h"
+#include <gtest/gtest.h>
+
+class TFakeGpioChipDriver: public TGpioChipDriver
+{
+    using TGpioLines = std::vector<PGpioLine>;
+    uint8_t LineReadVal;
+
+public:
+    TFakeGpioChipDriver(const PGpioLine& line, uint8_t fakeGpioLineVal): TGpioChipDriver()
+    {
+        LineReadVal = fakeGpioLineVal;
+        AddFakeGpioLine(line);
+        AutoDetectInterruptEdges();
+    }
+
+private:
+    void AddFakeGpioLine(const PGpioLine& line)
+    {
+        Lines[line->GetFd()].push_back(line);
+    }
+    void ReadLinesValues(const TGpioLines&)
+    {
+        for (const auto& fdLines: Lines) {
+            for (auto line: fdLines.second) {
+                line->SetCachedValue(LineReadVal);
+            }
+        }
+    }
+    void ReListenLine(PGpioLine)
+    {}
+};
+
+class TFakeGpioLine: public TGpioLine
+{
+public:
+    TFakeGpioLine(const TGpioLineConfig& config): TGpioLine(config)
+    {}
+    bool IsHandled() const
+    {
+        return true;
+    }
+    bool IsOutput() const
+    {
+        return false;
+    }
+    std::string DescribeShort() const
+    {
+        return "Mocked gpio line";
+    }
+};
+
+class TGpioCounterGetEdgeTest: public testing::Test
+{
+protected:
+    TGpioLineConfig fakeGpioLineConfig;
+
+    void SetUp()
+    {
+        fakeGpioLineConfig.DebounceTimeout = std::chrono::microseconds(0);
+        fakeGpioLineConfig.Offset = 0;
+        fakeGpioLineConfig.Name = "testline";
+        fakeGpioLineConfig.Type = "water_meter";
+    }
+};
+
+TEST_F(TGpioCounterGetEdgeTest, counter_edge_both)
+{
+    auto assumedEdge = EGpioEdge::BOTH;
+    fakeGpioLineConfig.InterruptEdge = assumedEdge;
+    const auto fakeGpioLine = std::make_shared<TFakeGpioLine>(fakeGpioLineConfig);
+    auto fakeGpioChipDriver = std::make_shared<TFakeGpioChipDriver>(fakeGpioLine, 0);
+
+    ASSERT_EQ(fakeGpioLine->GetInterruptEdge(), assumedEdge);
+    ASSERT_EQ(fakeGpioLine->GetCounter()->GetInterruptEdge(), assumedEdge);
+}
+
+TEST_F(TGpioCounterGetEdgeTest, counter_edge_rising)
+{
+    auto assumedEdge = EGpioEdge::RISING;
+    fakeGpioLineConfig.InterruptEdge = assumedEdge;
+    const auto fakeGpioLine = std::make_shared<TFakeGpioLine>(fakeGpioLineConfig);
+    auto fakeGpioChipDriver = std::make_shared<TFakeGpioChipDriver>(fakeGpioLine, 0);
+
+    ASSERT_EQ(fakeGpioLine->GetInterruptEdge(), assumedEdge);
+    ASSERT_EQ(fakeGpioLine->GetCounter()->GetInterruptEdge(), assumedEdge);
+}
+
+TEST_F(TGpioCounterGetEdgeTest, counter_edge_falling)
+{
+    auto assumedEdge = EGpioEdge::FALLING;
+    fakeGpioLineConfig.InterruptEdge = assumedEdge;
+    const auto fakeGpioLine = std::make_shared<TFakeGpioLine>(fakeGpioLineConfig);
+    auto fakeGpioChipDriver = std::make_shared<TFakeGpioChipDriver>(fakeGpioLine, 0);
+
+    ASSERT_EQ(fakeGpioLine->GetInterruptEdge(), assumedEdge);
+    ASSERT_EQ(fakeGpioLine->GetCounter()->GetInterruptEdge(), assumedEdge);
+}
+
+TEST_F(TGpioCounterGetEdgeTest, counter_edge_auto_falling)
+{
+    fakeGpioLineConfig.InterruptEdge = EGpioEdge::AUTO;
+    const auto fakeGpioLine = std::make_shared<TFakeGpioLine>(fakeGpioLineConfig);
+    const auto fakeGpioChipDriver = std::make_shared<TFakeGpioChipDriver>(fakeGpioLine, 1);
+
+    ASSERT_EQ(fakeGpioLine->GetInterruptEdge(), EGpioEdge::FALLING);
+    ASSERT_EQ(fakeGpioLine->GetCounter()->GetInterruptEdge(), EGpioEdge::FALLING);
+}
+
+TEST_F(TGpioCounterGetEdgeTest, counter_edge_auto_rising)
+{
+    fakeGpioLineConfig.InterruptEdge = EGpioEdge::AUTO;
+    const auto fakeGpioLine = std::make_shared<TFakeGpioLine>(fakeGpioLineConfig);
+    const auto fakeGpioChipDriver = std::make_shared<TFakeGpioChipDriver>(fakeGpioLine, 0);
+
+    ASSERT_EQ(fakeGpioLine->GetInterruptEdge(), EGpioEdge::RISING);
+    ASSERT_EQ(fakeGpioLine->GetCounter()->GetInterruptEdge(), EGpioEdge::RISING);
+}

--- a/wb-mqtt-gpio.schema.json
+++ b/wb-mqtt-gpio.schema.json
@@ -56,15 +56,20 @@
                 },
                 "edge": {
                     "type": "string",
+                    "_format": "slWb",
                     "title": "Pulse counter interrupt edge",
-                    "enum": [ "rising", "falling", "both", "auto" ],
-                    "default": "auto",
+                    "enum": [ "rising", "falling", "both" ],
+                    "default": "both",
                     "propertyOrder": 9,
                     "options": {
                         "dependencies": {
                             "type": ["watt_meter", "water_meter"]
                         },
-                        "enum_titles": ["rising", "falling", "both", "autodetect"]
+                        "enum_titles": ["rising", "falling", "both"],
+                        "show_opt_in": true,
+                        "wb": {
+                            "disabledEditorText": "autodetect"
+                        }
                     }
                 },
                 "multiplier": {
@@ -230,7 +235,6 @@
             "default": {
                 "inverted": false,
                 "type": "",
-                "edge": "auto",
                 "multiplier": 1,
                 "decimal_points_current": 2,
                 "decimal_points_total":2
@@ -404,6 +408,7 @@
             "rising": "Передний фронт",
             "falling": "Задний фронт",
             "both": "Передний и задний фронт",
+            "autodetect": "Автоматически определить фронт",
             "Number of pulses per unit (kWh or m^3)": "Количество импульсов на единицу измерения (кВт*ч или м^3)",
             "Number of decimal places in _current topic": "Число десятичных знаков канала с текущим показанием",
             "Number of decimal places in _total topic": "Число десятичных знаков канала с суммарным показанием",

--- a/wb-mqtt-gpio.schema.json
+++ b/wb-mqtt-gpio.schema.json
@@ -57,14 +57,14 @@
                 "edge": {
                     "type": "string",
                     "title": "Pulse counter interrupt edge",
-                    "enum": [ "rising", "falling", "both" ],
-                    "default": "both",
+                    "enum": [ "rising", "falling", "both", "auto" ],
+                    "default": "auto",
                     "propertyOrder": 9,
                     "options": {
                         "dependencies": {
                             "type": ["watt_meter", "water_meter"]
                         },
-                        "enum_titles": ["rising", "falling", "both"]
+                        "enum_titles": ["rising", "falling", "both", "autodetect"]
                     }
                 },
                 "multiplier": {
@@ -230,7 +230,7 @@
             "default": {
                 "inverted": false,
                 "type": "",
-                "edge": "both",
+                "edge": "auto",
                 "multiplier": 1,
                 "decimal_points_current": 2,
                 "decimal_points_total":2


### PR DESCRIPTION
починили счетчик "current":
![image](https://github.com/wirenboard/wb-mqtt-gpio/assets/25829054/1036d08f-8ee2-411f-acf9-6e219d8388a0)


был поломан мной (когда в дребезг лазил), и не мной (пересчет)

обнаружил, что не работает edge = "both" из-за самой логики wb-mqtt-gpio - нет в этом PR, будет отдельно