### PR TITLE
fix error with missing phandle

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-gpio (2.14.1) stable; urgency=medium
+
+  * Fix bug when missing WBIO modules are configured in the config
+
+ -- Aleksandr Kazadaev <aleksandr.kazadaev@wirenboard.com>  Tue, 23 Apr 2024 20:21:40 +0500
+
 wb-mqtt-gpio (2.14.0) stable; urgency=medium
 
   * Rewrite some internals to speed things up, no functional changes

--- a/generate-system-config.py
+++ b/generate-system-config.py
@@ -77,7 +77,7 @@ def of_get_prop_gpio(of_gpiochips, node, prop="gpios"):
         else:
             raise RuntimeError(f"Unknown xlate type {xlate_type}")
         if phandle not in of_gpiochips:
-            raise RuntimeError(f"Unknown phandle {phandle} (known phandles: {of_gpiochips.keys()})")
+            return f":{pin}:{attr}"  # checked, previous .sh script has exactly the same behavior
         return f"{of_gpiochips[phandle]}:{pin}:{attr}"
 
 


### PR DESCRIPTION
Фикс ошибки `RuntimeError: Unknown phandle 227 (known phandles: dict_keys(['32']))` при запуске сервиса.

Взял старый скрипт, подебажил его, проверил что там `of_get_prop_gpio()` просто возвращает адрес без идентификатора чипа, если он не найден в `OF_GPIOCHIPS`, сделал так же.

Протестил на 7.3 и 7.4 во всех сценариях (`нет wbio девайсов и нет их в конфиге`; `нет девайсов, но они есть в конфиге`; `есть девайсы, но их нет в конфиге`; `есть девайсы и они есть в конфиге`), всё ок.