### PR TITLE
introduce current counter falling as in modbus devices

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-gpio (2.14.3) stable; urgency=medium
+
+  * gpio_counter: fall "current" as in wb modbus devices
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Tue, 28 May 2024 15:37:42 +0300
+
 wb-mqtt-gpio (2.14.2) stable; urgency=medium
 
   * Add missed wb-utils dependency, no functional changes

--- a/src/gpio_counter.cpp
+++ b/src/gpio_counter.cpp
@@ -7,6 +7,7 @@
 #include <wblib/utils.h>
 
 #include <cassert>
+#include <cmath>
 
 #define LOG(logger) ::logger.Log() << "[gpio counter] "
 
@@ -18,6 +19,7 @@ const auto ID_POSTFIX_TOTAL = "_total";
 const auto ID_POSTFIX_CURRENT = "_current";
 const auto CURRENT_TIME_INTERVAL = 1;
 const auto NULL_TIME_INTERVAL = 100;
+const auto COUNTER_UPDATE_INTERVAL_US = 200000;
 
 TGpioCounter::TGpioCounter(const TGpioLineConfig& config)
     : Multiplier(config.Multiplier),
@@ -76,7 +78,9 @@ void TGpioCounter::Update(const TTimeIntervalUs& interval)
     if (interval > NULL_TIME_INTERVAL * PreviousInterval) {
         Current.Set(0);
     } else if (interval > CURRENT_TIME_INTERVAL * PreviousInterval) {
-        UpdateCurrent(interval);
+        // more info at https://wirenboard.com/wiki/Frequency_registers
+        auto divider = std::pow(2, (interval.count() / COUNTER_UPDATE_INTERVAL_US));
+        Current.Set(Current.Get() / divider);
     }
 }
 

--- a/test/gpiocounter.test.cpp
+++ b/test/gpiocounter.test.cpp
@@ -121,3 +121,21 @@ TEST_F(TGpioCounterGetEdgeTest, counter_edge_auto_rising)
     ASSERT_EQ(fakeGpioLine->GetInterruptEdge(), EGpioEdge::RISING);
     ASSERT_EQ(fakeGpioLine->GetCounter()->GetInterruptEdge(), EGpioEdge::RISING);
 }
+
+TEST_F(TGpioCounterGetEdgeTest, counter_update_current)
+{
+    fakeGpioLineConfig.InterruptEdge = EGpioEdge::RISING;
+    const auto fakeGpioLine = std::make_shared<TFakeGpioLine>(fakeGpioLineConfig);
+    auto interval = std::chrono::microseconds(100000);
+    auto assumedCurrent = (3600.0 * 1000000 * 1.0 / (interval.count() * fakeGpioLineConfig.Multiplier));
+
+    fakeGpioLine->GetCounter()->HandleInterrupt(EGpioEdge::RISING, interval);
+    ASSERT_EQ(fakeGpioLine->GetCounter()->GetTotal(), 1);
+    ASSERT_EQ(fakeGpioLine->GetCounter()->GetCurrent(), assumedCurrent);
+
+    fakeGpioLine->GetCounter()->Update(std::chrono::microseconds(200000));
+    ASSERT_EQ(fakeGpioLine->GetCounter()->GetCurrent(), assumedCurrent / 2);
+
+    fakeGpioLine->GetCounter()->Update(std::chrono::microseconds(200000));
+    ASSERT_EQ(fakeGpioLine->GetCounter()->GetCurrent(), assumedCurrent / 4);
+}


### PR DESCRIPTION
@dust70 жаловался, что у счетчиков "current" спадает очень медленно -> решили сделать также, как у ембеддеров

https://wirenboard.youtrack.cloud/issue/SOFT-3060/Konsistentnoe-povedenie-schetchikov-wb-mqtt-gpio

было:

https://github.com/wirenboard/wb-mqtt-gpio/assets/25829054/e17934a5-e52c-47f5-b4ba-7b0f319afeb1

стало:

https://github.com/wirenboard/wb-mqtt-gpio/assets/25829054/77fdb508-d3f7-4a46-9239-aa842da65a52


