### PR TITLE
Fix restoration of outputs state

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-gpio (2.15.0) stable; urgency=medium
+
+  * Fix restoration of outputs state after unexpected controller restart
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Tue, 09 Jul 2024 11:50:08 +0500
+
 wb-mqtt-gpio (2.14.3) stable; urgency=medium
 
   * gpio_counter: fall "current" as in wb modbus devices

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Maintainer: Evgeny Boger <boger@contactless.ru>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.2
-Build-Depends: debhelper (>= 10), pkg-config, libwbmqtt1-4-dev, libgmock-dev, libwbmqtt1-4-test-utils
+Build-Depends: debhelper (>= 10), pkg-config, libwbmqtt1-5-dev (>= 5.1.0), libgmock-dev, libwbmqtt1-5-test-utils (>= 5.1.0)
 Homepage: https://github.com/wirenboard/wb-mqtt-gpio
 
 Package: wb-mqtt-gpio

--- a/src/gpio_driver.cpp
+++ b/src/gpio_driver.cpp
@@ -56,7 +56,8 @@ TFuture<PControl> CreateOutputControl(WBMQTT::PLocalDevice device,
                                                    .SetUserData(line)
                                                    .SetRawValue(lineConfig.InitialState ? "1" : "0")
                                                    .SetError(error)
-                                                   .SetDoLoadPrevious(lineConfig.LoadPreviousState));
+                                                   .SetDoLoadPrevious(lineConfig.LoadPreviousState)
+                                                   .SetDurable());
     setLineValueFn(futureControl.GetValue()->GetValue().As<bool>() ? 1 : 0);
     return futureControl;
 }

--- a/src/types.h
+++ b/src/types.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 enum class EGpioEdge : uint8_t


### PR DESCRIPTION
Сохраняем состояние выходов немедленно после изменения на диск, чтобы восстановить после неожиданной пропажи питания