### PR TITLE
Feature/rework flush

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-gpio (2.16.0) stable; urgency=medium
+
+  * Clear error on successful gpio ioclt
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Thu, 29 Aug 2024 04:12:45 +0300
+
 wb-mqtt-gpio (2.15.2) stable; urgency=medium
 
   * Fix tests, no functional changes

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,9 @@
 wb-mqtt-gpio (2.16.0) stable; urgency=medium
 
-  * Clear error on successful gpio ioclt
+  * Auto recover error on successful gpio ioclt
+  * Behavior on recover: input -> as is on gpio; output -> set last successful val
 
- -- Vladimir Romanov <v.romanov@wirenboard.ru>  Thu, 29 Aug 2024 04:12:45 +0300
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Thu, 23 jan 2025 19:02:18 +0300
 
 wb-mqtt-gpio (2.15.2) stable; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -314,13 +314,13 @@ wb-mqtt-gpio (2.0.2) unstable; urgency=medium
 
  -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Tue, 07 Jul 2020 11:57:01 +0500
 
-wb-mqtt-gpio (2.0.1) UNRELEASED; urgency=medium
+wb-mqtt-gpio (2.0.1) unstable; urgency=medium
 
   * rename to wb-mqtt-gpio
 
  -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Thu, 02 Jul 2020 15:17:01 +0500
 
-wb-homa-gpio (2.0.0) UNRELEASED; urgency=medium
+wb-homa-gpio (2.0.0) unstable; urgency=medium
 
   * reimplemented driver on new character device GPIO API
   * new libwbmqtt

--- a/debian/control
+++ b/debian/control
@@ -13,12 +13,13 @@ Homepage: https://github.com/wirenboard/wb-mqtt-gpio
 
 Package: wb-mqtt-gpio
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, ucf, wb-configs (>= 1.82.2), wb-utils
+Depends: ${shlibs:Depends}, ${misc:Depends}, python3, ucf, wb-configs (>= 1.82.2), wb-utils
 Breaks: wb-mqtt-confed (<< 1.7.0), wb-homa-gpio (<< 2.0.1)
 Replaces: wb-homa-gpio (<< 2.0.1)
 Conflicts: wb-homa-gpio (<< 2.0.1)
 Suggests: linux-image-wb6 (>= 5.10.35-wb1)
-Description: Wiren Board Smart Home MQTT generic sysfs GPIO driver compatible with HomA conventions
+Description: Wiren Board Smart Home MQTT generic GPIO driver compatible with HomA conventions
+ Uses libgpiod under the hood.
 
 Package: wb-homa-gpio
 Depends: wb-mqtt-gpio (= ${binary:Version}), ${misc:Depends}

--- a/src/gpio_chip_driver.cpp
+++ b/src/gpio_chip_driver.cpp
@@ -554,6 +554,9 @@ void TGpioChipDriver::PollLinesValues(const TGpioLines& lines)
         if (recovery) {
             line->ClearError();
             LOG(Info) << "Treating " << line->DescribeShort() << " as alive again";
+            if (line->GetConfig()->Direction == EGpioDirection::Output) {
+                FlushMcp23xState(line);
+            }
         }
 
         LOG(Debug) << "Poll " << line->DescribeShort() << " old value: " << oldValue << " new value: " << newValue;

--- a/src/gpio_chip_driver.cpp
+++ b/src/gpio_chip_driver.cpp
@@ -628,10 +628,14 @@ void TGpioChipDriver::ReInitOutput(PGpioLine line)
         if (!FlushMcp23xState(line))
             LOG(Error) << "Unable to re-init output " << line->DescribeShort();
 
+    const auto& config = line->GetConfig();
+    auto oldstate = config->InitialState;
+    config->InitialState = line->GetValue();
     bool ok = InitOutput(line);
     if (!ok) {
         LOG(Error) << "Unable to re-init output " << line->DescribeShort();
     }
+    config->InitialState = oldstate;
 }
 
 void TGpioChipDriver::AutoDetectInterruptEdges()

--- a/src/gpio_chip_driver.h
+++ b/src/gpio_chip_driver.h
@@ -53,6 +53,7 @@ private:
     virtual void ReadLinesValues(const TGpioLines&);
 
     virtual void ReListenLine(PGpioLine);
+    virtual void ReInitOutput(PGpioLine);
     void ReadInputValues();
 
     bool HandleTimerInterrupt(const PGpioLine&);

--- a/src/gpio_chip_driver.h
+++ b/src/gpio_chip_driver.h
@@ -44,7 +44,7 @@ public:
 private:
     bool ReleaseLineIfUsed(const PGpioLine&);
     bool TryListenLine(const PGpioLine&);
-    bool InitOutput(const PGpioLine&);
+    bool InitOutput(const PGpioLine&, uint8_t);
     bool FlushMcp23xState(const PGpioLine&);
     bool InitInputInterrupts(const PGpioLine&);
     bool InitLinesPolling(uint32_t flags, const TGpioLines& lines);

--- a/src/gpio_line.cpp
+++ b/src/gpio_line.cpp
@@ -249,6 +249,11 @@ void TGpioLine::SetError(const std::string& err)
         Error += err;
 }
 
+void TGpioLine::ClearError()
+{
+    Error.clear();
+}
+
 const std::string& TGpioLine::GetError() const
 {
     return Error;

--- a/src/gpio_line.h
+++ b/src/gpio_line.h
@@ -52,6 +52,7 @@ public:
     void SetCachedValueUnfiltered(uint8_t);
     const std::string& GetError() const;
     void SetError(const std::string&);
+    void ClearError();
     PGpioChip AccessChip() const;
     virtual bool IsHandled() const;
     void SetFd(int);


### PR DESCRIPTION
доделал автовосстановление из [соседнего драфта](https://github.com/wirenboard/wb-mqtt-gpio/pull/69)
основная идея - надо было отпустить линию перед flush

погонял на wb7 и wb8 - работает на удивление неплохо