### PR TITLE
Fix reading of decimal_points_current and decimal_points_total

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-mqtt-gpio (2.16.1) stable; urgency=medium
+
+  * Fix reading of decimal_points_current and decimal_points_total config options
+  * Set default values for decimal_points_current and decimal_points_total to 3
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Tue, 18 Mar 2025 15:55:02 +0500
+
 wb-mqtt-gpio (2.16.0) stable; urgency=medium
 
   * Auto recover error on successful gpio ioclt

--- a/src/config.h
+++ b/src/config.h
@@ -5,6 +5,8 @@
 #include <vector>
 #include <wblib/driver_args.h>
 
+const int DEFAULT_DECIMAL_PLACES = 3;
+
 enum class EGpioDirection
 {
     Input,
@@ -22,8 +24,8 @@ struct TGpioLineConfig
     EGpioEdge InterruptEdge = EGpioEdge::AUTO;
     std::string Type;
     float Multiplier = 1.0;
-    int DecimalPlacesTotal = -1;
-    int DecimalPlacesCurrent = -1;
+    int DecimalPlacesTotal = DEFAULT_DECIMAL_PLACES;
+    int DecimalPlacesCurrent = DEFAULT_DECIMAL_PLACES;
     bool InitialState = false;
     bool LoadPreviousState = true;
     std::chrono::microseconds DebounceTimeout = std::chrono::microseconds(10000);

--- a/src/gpio_counter.cpp
+++ b/src/gpio_counter.cpp
@@ -36,14 +36,10 @@ TGpioCounter::TGpioCounter(const TGpioLineConfig& config)
         TotalType = "power_consumption";
         CurrentType = "power";
         ConvertingMultiplier = 1000; // convert kW to W (1/h)
-        DecimalPlacesCurrent = (DecimalPlacesCurrent == -1) ? 2 : DecimalPlacesCurrent;
-        DecimalPlacesTotal = (DecimalPlacesTotal == -1) ? 3 : DecimalPlacesTotal;
     } else if (config.Type == WATER_METER) {
         TotalType = "water_consumption";
         CurrentType = "water_flow";
         ConvertingMultiplier = 1.0; // 1/h
-        DecimalPlacesCurrent = (DecimalPlacesCurrent == -1) ? 3 : DecimalPlacesCurrent;
-        DecimalPlacesTotal = (DecimalPlacesTotal == -1) ? 2 : DecimalPlacesTotal;
     } else {
         LOG(Error) << "Unknown gpio type";
         wb_throw(TGpioDriverException, "unknown GPIO type: '" + config.Type + "'");

--- a/wb-mqtt-gpio.schema.json
+++ b/wb-mqtt-gpio.schema.json
@@ -237,7 +237,7 @@
                 "type": "",
                 "multiplier": 1,
                 "decimal_points_current": 3,
-                "decimal_points_total":3
+                "decimal_points_total": 3
             },
             "options": {
                 "disable_properties": true

--- a/wb-mqtt-gpio.schema.json
+++ b/wb-mqtt-gpio.schema.json
@@ -236,8 +236,8 @@
                 "inverted": false,
                 "type": "",
                 "multiplier": 1,
-                "decimal_points_current": 2,
-                "decimal_points_total":2
+                "decimal_points_current": 3,
+                "decimal_points_total":3
             },
             "options": {
                 "disable_properties": true


### PR DESCRIPTION
  * Fix reading of decimal_points_current and decimal_points_total config options
  * Set default values for decimal_points_current and decimal_points_total to 3

В схеме были прописаны значения по умолчанию. Если они не менялись пользователем, то не записывались в конфиг. Если в конфиге не было этих параметров, использовались захардкоженые значения, которые отличаются от значений в схеме. В результате, отображалось одно, а использовалось другое значение.
Сделать "красиво" в веб-интерфейсе, и чтоб набор значений по умолчанию зависел от типа счётчика, не смог. По этому просто сделал везде одинаково.