### PR TITLE
Fix counters update blocking bug

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-gpio (2.16.2) stable; urgency=medium
+
+  * Fix counters uptate blocking bug
+
+ -- Ilya Titov <ilya.titov@wirenboard.com>  Thu, 24 Apr 2025 08:36:53 +0000
+
 wb-mqtt-gpio (2.16.1) stable; urgency=medium
 
   * Fix reading of decimal_points_current and decimal_points_total config options

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 wb-mqtt-gpio (2.16.2) stable; urgency=medium
 
   * Fix counters uptate blocking bug
+  * Fix false startup interrupts bug
 
  -- Ilya Titov <ilya.titov@wirenboard.com>  Thu, 24 Apr 2025 08:36:53 +0000
 

--- a/src/gpio_chip_driver.cpp
+++ b/src/gpio_chip_driver.cpp
@@ -250,9 +250,14 @@ bool TGpioChipDriver::HandleGpioInterrupt(const PGpioLine& line, const TInterrup
                 line->SetError("r");
                 return false;
             }
-            line->SetCachedValueUnfiltered(data.values[0]); // all interrupt events
-            SetIntervalTimer(line->GetTimerFd(), line->GetConfig()->DebounceTimeout);
-            isHandled = true;
+
+            bool oldValue = line->GetValueUnfiltered();
+            bool newValue = data.values[0];
+            if (oldValue != newValue) {
+                line->SetCachedValueUnfiltered(data.values[0]); // all interrupt events
+                SetIntervalTimer(line->GetTimerFd(), line->GetConfig()->DebounceTimeout);
+                isHandled = true;
+            }
         }
     }
     return isHandled;

--- a/src/gpio_chip_driver.cpp
+++ b/src/gpio_chip_driver.cpp
@@ -564,8 +564,6 @@ void TGpioChipDriver::PollLinesValues(const TGpioLines& lines)
                 if (line->HandleInterrupt(edge, now) == EInterruptStatus::Handled) {
                     line->SetCachedValue(newValue);
                 }
-            } else { /* in other case let line do idle actions */
-                line->Update();
             }
         } else { /* for output just set value to cache: it will publish it if
                     changed */

--- a/src/gpio_driver.cpp
+++ b/src/gpio_driver.cpp
@@ -271,6 +271,8 @@ void TGpioDriver::Start()
                                         for (const auto& chipDriver: ChipDrivers) {
                                             FOR_EACH_LINE(chipDriver, line)
                                             {
+                                                line->Update();
+
                                                 const auto err = line->GetError();
                                                 if (!err.empty()) {
                                                     device->GetControl(line->GetConfig()->Name)->SetError(tx, err);


### PR DESCRIPTION
* исправил ошибку, из-за которой мгновенные значения счетчика не спадали, пока на другом канале присутствуют импульсы
* исправил ошибку, из-за которой, в момент запуска службы, на каждый счетный канал засчитывался один ложный импульс