### PR TITLE
Fix all inputs disappearing when counter set on non-interrupt chip

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-mqtt-gpio (2.17.1) stable; urgency=medium
+
+  * Fix all inputs disappearing when a counter is configured on a GPIO chip
+    without interrupt support (e.g. wbec-gpio MOD inputs)
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Fri, 05 Jun 2026 12:00:00 +0400
+
 wb-mqtt-gpio (2.17.0) stable; urgency=medium
 
   * Port for Debian 13

--- a/src/gpio_chip_driver.cpp
+++ b/src/gpio_chip_driver.cpp
@@ -694,7 +694,15 @@ void TGpioChipDriver::AutoDetectInterruptEdges()
         line->GetCounter()->SetInterruptEdge(edge);
         line->GetConfig()->InterruptEdge = edge;
 
-        ReListenLine(line);
+        // Re-listen only for lines that are actually handled via interrupts.
+        // A counter line on a chip without interrupt support (e.g. wbec-gpio
+        // MOD inputs) falls back to polling and shares a single fd with all the
+        // other polled lines. ReListenLine() would erase that shared fd, killing
+        // every line behind it, and then fail to re-establish the event request.
+        // Polling already resolves the now-concrete edge, so nothing to re-listen.
+        if (line->GetInterruptSupport() == EInterruptSupport::YES) {
+            ReListenLine(line);
+        }
     }
 }
 

--- a/test/gpiocounter.test.cpp
+++ b/test/gpiocounter.test.cpp
@@ -205,6 +205,7 @@ protected:
         config.Offset = offset;
         config.Name = "line" + std::to_string(offset);
         config.Type = type;
+        config.Direction = EGpioDirection::Input;
         config.InterruptEdge = EGpioEdge::AUTO;
         return config;
     }
@@ -214,7 +215,9 @@ protected:
 // must not trigger ReListenLine, and the shared fd must keep all its lines.
 TEST_F(TGpioCounterPollingTest, polled_counter_keeps_shared_fd)
 {
-    // Deliberately out-of-range fd: the base dtor close()s every fd in Lines.
+    // A fake, high-numbered fd, chosen to make a collision with a real open fd
+    // in this test process unlikely. The base dtor close()s every fd key in
+    // Lines; close() on a fd this process never opened just fails harmlessly.
     const int sharedFd = 100042;
 
     auto counterLine = std::make_shared<TFakeGpioLine>(MakeLineConfig(0, "water_meter"));

--- a/test/gpiocounter.test.cpp
+++ b/test/gpiocounter.test.cpp
@@ -159,9 +159,13 @@ public:
     }
 
     // Put the line onto a shared polling fd, mimicking InitLinesPolling().
+    // NB: we set only the map key, NOT line->SetFd(): SetFd() calls UpdateInfo()
+    // which ioctl()s AccessChip(), and these fake lines have no chip — in a
+    // release (NDEBUG) build the assert in AccessChip() is a no-op, so it would
+    // dereference a null shared_ptr and segfault. TFakeGpioLine::IsHandled()
+    // already returns true unconditionally, so the fd on the line is not needed.
     void AddPolledLine(const PGpioLine& line, int sharedFd)
     {
-        line->SetFd(sharedFd);
         Lines[sharedFd].push_back(line);
     }
 

--- a/test/gpiocounter.test.cpp
+++ b/test/gpiocounter.test.cpp
@@ -139,3 +139,115 @@ TEST_F(TGpioCounterGetEdgeTest, counter_update_current)
     fakeGpioLine->GetCounter()->Update(std::chrono::microseconds(200000));
     ASSERT_EQ(fakeGpioLine->GetCounter()->GetCurrent(), assumedCurrent / 4);
 }
+
+// Regression harness for the "all inputs disappearing" bug. A counter line on a
+// chip without interrupt support shares a single polled fd with all the other
+// inputs. AutoDetectInterruptEdges() must NOT call ReListenLine() for such a
+// line, otherwise the shared fd is erased (and closed), killing every input
+// behind it.
+class TFakePolledChipDriver: public TGpioChipDriver
+{
+    using TGpioLines = std::vector<PGpioLine>;
+    uint8_t LineReadVal;
+
+public:
+    int ReListenCalls = 0;
+
+    explicit TFakePolledChipDriver(uint8_t fakeGpioLineVal): TGpioChipDriver()
+    {
+        LineReadVal = fakeGpioLineVal;
+    }
+
+    // Put the line onto a shared polling fd, mimicking InitLinesPolling().
+    void AddPolledLine(const PGpioLine& line, int sharedFd)
+    {
+        line->SetFd(sharedFd);
+        Lines[sharedFd].push_back(line);
+    }
+
+    void Detect()
+    {
+        AutoDetectInterruptEdges();
+    }
+
+    size_t LinesOnFd(int fd) const
+    {
+        const auto it = Lines.find(fd);
+        return it == Lines.end() ? 0 : it->second.size();
+    }
+
+private:
+    void ReadLinesValues(const TGpioLines&) override
+    {
+        for (const auto& fdLines: Lines) {
+            for (const auto& line: fdLines.second) {
+                line->SetCachedValue(LineReadVal);
+            }
+        }
+    }
+    void ReListenLine(PGpioLine) override
+    {
+        ++ReListenCalls;
+    }
+};
+
+class TGpioCounterPollingTest: public testing::Test
+{
+protected:
+    TGpioLineConfig MakeLineConfig(uint32_t offset, const std::string& type)
+    {
+        TGpioLineConfig config;
+        config.DebounceTimeout = std::chrono::microseconds(0);
+        config.Offset = offset;
+        config.Name = "line" + std::to_string(offset);
+        config.Type = type;
+        config.InterruptEdge = EGpioEdge::AUTO;
+        return config;
+    }
+};
+
+// A polled counter line (no interrupt support) sharing an fd with a plain input
+// must not trigger ReListenLine, and the shared fd must keep all its lines.
+TEST_F(TGpioCounterPollingTest, polled_counter_keeps_shared_fd)
+{
+    // Deliberately out-of-range fd: the base dtor close()s every fd in Lines.
+    const int sharedFd = 100042;
+
+    auto counterLine = std::make_shared<TFakeGpioLine>(MakeLineConfig(0, "water_meter"));
+    counterLine->SetInterruptSupport(EInterruptSupport::NO);
+
+    auto plainInput = std::make_shared<TFakeGpioLine>(MakeLineConfig(1, ""));
+    plainInput->SetInterruptSupport(EInterruptSupport::NO);
+
+    auto driver = std::make_shared<TFakePolledChipDriver>(1);
+    driver->AddPolledLine(counterLine, sharedFd);
+    driver->AddPolledLine(plainInput, sharedFd);
+
+    driver->Detect();
+
+    // Edge must still be auto-detected via polling (read value 1 => falling).
+    ASSERT_EQ(counterLine->GetCounter()->GetInterruptEdge(), EGpioEdge::FALLING);
+    // But no re-listen must happen for a polled line ...
+    ASSERT_EQ(driver->ReListenCalls, 0);
+    // ... and the shared fd must keep both lines.
+    ASSERT_EQ(driver->LinesOnFd(sharedFd), 2u);
+}
+
+// A counter line that does support interrupts must still be re-listened so the
+// freshly detected edge takes effect.
+TEST_F(TGpioCounterPollingTest, interrupt_counter_is_relistened)
+{
+    const int ownFd = 100007;
+
+    auto counterLine = std::make_shared<TFakeGpioLine>(MakeLineConfig(0, "water_meter"));
+    counterLine->SetInterruptSupport(EInterruptSupport::YES);
+
+    auto driver = std::make_shared<TFakePolledChipDriver>(0);
+    driver->AddPolledLine(counterLine, ownFd);
+
+    driver->Detect();
+
+    // Read value 0 => rising.
+    ASSERT_EQ(counterLine->GetCounter()->GetInterruptEdge(), EGpioEdge::RISING);
+    ASSERT_EQ(driver->ReListenCalls, 1);
+}


### PR DESCRIPTION
A counter line on a GPIO chip without interrupt support (e.g. wbec-gpio MOD inputs) falls back to polling, where it shares a single fd with every other polled line. AutoDetectInterruptEdges() then called ReListenLine() on that line, which erased the shared fd (removing all sibling inputs) and failed to re-establish an event request. In release builds the assert(ok) guarding the failure is compiled out (-DNDEBUG), so all MOD1/MOD2 inputs silently vanished.

Only re-listen lines actually handled via interrupts; polling already resolves the auto-detected edge, so polled counter lines need no relisten.

___________________________________
**Что происходит; кому и зачем нужно:**


___________________________________
**Что поменялось для пользователей:**


___________________________________
**Как проверял/а:**


