### PR TITLE
Fix phantom counter increments

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-mqtt-gpio (2.18.0) stable; urgency=medium
+
+  * Fix phantom counter increments on idle inputs: a pulse is now counted only
+    when the input level actually holds for the debounce time.
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Wed, 17 Jun 2026 12:00:00 +0400
+
 wb-mqtt-gpio (2.17.1) stable; urgency=medium
 
   * Fix all inputs disappearing when a counter is configured on a GPIO chip

--- a/src/gpio_chip_driver.cpp
+++ b/src/gpio_chip_driver.cpp
@@ -240,32 +240,19 @@ bool TGpioChipDriver::HandleGpioInterrupt(const PGpioLine& line, const TInterrup
                      "unable to read line event data: gpioevent_data failed with " + string(strerror(errno)));
         }
 
-        auto edge = data.id == GPIOEVENT_EVENT_RISING_EDGE ? EGpioEdge::RISING : EGpioEdge::FALLING;
         auto time = ctx.ToSteadyClock(data.timestamp);
 
-        if (line->HandleInterrupt(edge, time) == EInterruptStatus::Handled) { // update gpioline's last interruption ts
-            gpiohandle_data data;
-            if (ioctl(fd, GPIOHANDLE_GET_LINE_VALUES_IOCTL, &data) < 0) {
-                LOG(Error) << "GPIOHANDLE_GET_LINE_VALUES_IOCTL failed: " << strerror(errno);
-                line->SetError("r");
-                return false;
-            }
-
-            // false interrupt generated on every service startup
-            // ignore it to prevent incorrect counter updates
-            bool oldValue = line->GetValueUnfiltered();
-            bool newValue = data.values[0];
-            if ((line->GetInterruptEdge() == EGpioEdge::BOTH && oldValue == newValue) ||
-                (line->GetSkipInterrupt() && !newValue))
-            {
-                line->ClearSkipInterrupt();
-                return false;
-            }
-
-            line->SetCachedValueUnfiltered(data.values[0]); // all interrupt events
-            SetIntervalTimer(line->GetTimerFd(), line->GetConfig()->DebounceTimeout);
-            isHandled = true;
+        gpiohandle_data values;
+        if (ioctl(fd, GPIOHANDLE_GET_LINE_VALUES_IOCTL, &values) < 0) {
+            LOG(Error) << "GPIOHANDLE_GET_LINE_VALUES_IOCTL failed: " << strerror(errno);
+            line->SetError("r");
+            return false;
         }
+
+        line->SetCachedValueUnfiltered(values.values[0]);
+        line->HandleInterrupt(time); // record interrupt time, (re)arm debounce window
+        SetIntervalTimer(line->GetTimerFd(), line->GetConfig()->DebounceTimeout);
+        isHandled = true;
     }
     return isHandled;
 }
@@ -378,24 +365,7 @@ bool TGpioChipDriver::TryListenLine(const PGpioLine& line)
     req.lineoffset = line->GetOffset();
     req.handleflags = GetFlagsFromConfig(*config);
 
-    req.eventflags = 0;
-
-    switch (config->InterruptEdge) {
-        case EGpioEdge::RISING:
-            req.eventflags |= GPIOEVENT_REQUEST_RISING_EDGE;
-            break;
-        case EGpioEdge::FALLING:
-            req.eventflags |= GPIOEVENT_REQUEST_FALLING_EDGE;
-            break;
-        case EGpioEdge::BOTH:
-            req.eventflags |= GPIOEVENT_REQUEST_BOTH_EDGES;
-            break;
-        case EGpioEdge::AUTO:
-            req.eventflags |= GPIOEVENT_REQUEST_BOTH_EDGES;
-            break;
-        default:
-            wb_throw(TGpioDriverException, "Unknown interrupt edge in config");
-    }
+    req.eventflags = GPIOEVENT_REQUEST_BOTH_EDGES;
 
     errno = 0;
     if (ioctl(Chip->GetFd(), GPIO_GET_LINEEVENT_IOCTL, &req) < 0) {
@@ -572,10 +542,8 @@ void TGpioChipDriver::PollLinesValues(const TGpioLines& lines)
         if (!line->IsOutput()) {
             /* if value changed for input we simulate interrupt */
             if (recovery || oldValue != newValue) {
-                auto edge = newValue ? EGpioEdge::RISING : EGpioEdge::FALLING;
-                if (line->HandleInterrupt(edge, now) == EInterruptStatus::Handled) {
-                    line->SetCachedValue(newValue);
-                }
+                line->HandleInterrupt(now);
+                line->SetCachedValue(newValue);
             }
         } else { /* for output just set value to cache: it will publish it if
                     changed */

--- a/src/gpio_line.cpp
+++ b/src/gpio_line.cpp
@@ -23,17 +23,12 @@ TGpioLine::TGpioLine(const PGpioChip& chip, const TGpioLineConfig& config)
       TimerFd(-1),
       Value(0),
       ValueUnfiltered(0),
-      InterruptSupport(EInterruptSupport::UNKNOWN),
-      SkipInterrupt(false)
+      InterruptSupport(EInterruptSupport::UNKNOWN)
 {
     Config = WBMQTT::MakeUnique<TGpioLineConfig>(config);
 
     if (!config.Type.empty()) {
         Counter = WBMQTT::MakeUnique<TGpioCounter>(config);
-        // set skip interrupt flag to prevent false service startup interrupts when using gpiochip0
-        if (Counter->GetInterruptEdge() != EGpioEdge::BOTH && AccessChip()->GetNumber() == 0) {
-            SkipInterrupt = true;
-        }
     }
 
     if (chip->IsValid())
@@ -300,21 +295,9 @@ std::chrono::microseconds TGpioLine::GetIntervalFromPreviousInterrupt(const TTim
     return chrono::duration_cast<chrono::microseconds>(interruptTimePoint - GetInterruptionTimepoint());
 }
 
-EInterruptStatus TGpioLine::HandleInterrupt(EGpioEdge edge, const TTimePoint& interruptTimePoint)
+void TGpioLine::HandleInterrupt(const TTimePoint& interruptTimePoint)
 {
-    assert(edge != EGpioEdge::BOTH);
-
-    auto interruptEdge = GetInterruptEdge();
-    if (interruptEdge != EGpioEdge::BOTH && interruptEdge != edge) {
-        if (Debug.IsEnabled()) {
-            LOG(Debug) << DescribeShort() << " handle interrupt. Edge: " << GpioEdgeToString(edge)
-                       << " interval: " << GetIntervalFromPreviousInterrupt(interruptTimePoint).count() << " us [skip]";
-        }
-        return EInterruptStatus::SKIP;
-    }
-
     PreviousInterruptionTimePoint = interruptTimePoint;
-    return EInterruptStatus::Handled;
 }
 
 void TGpioLine::Update()
@@ -347,34 +330,43 @@ EInterruptSupport TGpioLine::GetInterruptSupport() const
     return InterruptSupport;
 }
 
-bool TGpioLine::GetSkipInterrupt() const
-{
-    return SkipInterrupt;
-}
-
-void TGpioLine::ClearSkipInterrupt()
-{
-    SkipInterrupt = false;
-}
-
 bool TGpioLine::UpdateIfStable(const TTimePoint& checkTimePoint)
 {
     auto fromLastTs = GetIntervalFromPreviousInterrupt(checkTimePoint);
-    if (fromLastTs > GetConfig()->DebounceTimeout) {
-        SetCachedValue(GetValueUnfiltered());
-        LOG(Debug) << "Value (" << static_cast<bool>(GetValueUnfiltered()) << ") on (" << GetName() << " is stable for "
-                   << fromLastTs.count() << "us";
+    if (fromLastTs <= GetConfig()->DebounceTimeout) {
+        return false;
+    }
 
-        const auto& gpioCounter = GetCounter();
-        if (gpioCounter) {
+    // The line has held a steady level for the whole debounce window, so the
+    // settled level is real (not bounce/noise). Commit it as the filtered value.
+    bool previousStable = GetValue();
+    bool newStable = GetValueUnfiltered();
+    SetCachedValue(newStable);
+    LOG(Debug) << "Value (" << newStable << ") on (" << GetName() << " is stable for " << fromLastTs.count() << "us";
+
+    const auto& gpioCounter = GetCounter();
+    if (gpioCounter) {
+        // Count only when the held level is a real transition in the configured
+        // direction.
+        bool counted;
+        switch (GetInterruptEdge()) {
+            case EGpioEdge::RISING:
+                counted = (!previousStable && newStable);
+                break;
+            case EGpioEdge::FALLING:
+                counted = (previousStable && !newStable);
+                break;
+            default: // BOTH
+                counted = (previousStable != newStable);
+                break;
+        }
+
+        if (counted) {
             auto fromLastStableValTs =
                 chrono::duration_cast<chrono::microseconds>(checkTimePoint - PreviousStableValAcquiredTimePoint);
             gpioCounter->HandleInterrupt(GetInterruptEdge(), fromLastStableValTs);
+            PreviousStableValAcquiredTimePoint = checkTimePoint;
         }
-
-        PreviousStableValAcquiredTimePoint = checkTimePoint;
-        return true;
-    } else {
-        return false;
     }
+    return true;
 }

--- a/src/gpio_line.h
+++ b/src/gpio_line.h
@@ -26,7 +26,6 @@ class TGpioLine
     TValue<uint8_t> ValueUnfiltered;
 
     EInterruptSupport InterruptSupport;
-    bool SkipInterrupt;
 
 public:
     TGpioLine(const PGpioChip& chip, const TGpioLineConfig& config);
@@ -61,14 +60,12 @@ public:
     void SetTimerFd(int);
     int GetTimerFd() const;
     EGpioEdge GetInterruptEdge() const;
-    EInterruptStatus HandleInterrupt(EGpioEdge, const TTimePoint&);
+    void HandleInterrupt(const TTimePoint&);
     void Update();
     const PUGpioCounter& GetCounter() const;
     const PUGpioLineConfig& GetConfig() const;
     void SetInterruptSupport(EInterruptSupport interruptSupport);
     EInterruptSupport GetInterruptSupport() const;
-    bool GetSkipInterrupt() const;
-    void ClearSkipInterrupt();
     std::chrono::microseconds GetIntervalFromPreviousInterrupt(const TTimePoint& interruptTimePoint) const;
     bool UpdateIfStable(const TTimePoint& checkTimePoint);
     const TTimePoint& GetInterruptionTimepoint() const;

--- a/src/types.h
+++ b/src/types.h
@@ -21,12 +21,6 @@ enum class EInterruptSupport : uint8_t
     NO
 };
 
-enum class EInterruptStatus : uint8_t
-{
-    SKIP,
-    Handled
-};
-
 template<typename T> class TValue
 {
     T Value;

--- a/test/debounce.test.cpp
+++ b/test/debounce.test.cpp
@@ -36,7 +36,7 @@ void TDebounceTest::InitGpioLine(const PGpioLine& gpioLine, uint8_t gpioValue)
 
 void TDebounceTest::HandleGpioEvent(const PGpioLine& gpioLine, uint8_t gpioValue, TTimePoint ts)
 {
-    gpioLine->HandleInterrupt(EGpioEdge::RISING, ts);
+    gpioLine->HandleInterrupt(ts);
     gpioLine->SetCachedValueUnfiltered(gpioValue);
 
     ASSERT_EQ(gpioLine->GetValueUnfiltered(), gpioValue);
@@ -105,4 +105,102 @@ TEST_F(TDebounceTest, count_debounce_is_firing)
 
     ASSERT_EQ(fakeGpioLine->GetCounter()->GetTotal(), 0);
     ASSERT_EQ(fakeGpioLine->GetCounter()->GetCurrent(), 0);
+}
+
+// Single-edge counters count a transition only when the settled level is a real
+// change in the configured direction that held for the whole debounce window.
+// A short spike that returns within the window — even one momentarily read as
+// high — is not a transition once the line settles, so it must not be counted.
+// (The opposite edge that reveals the return is visible because both kernel
+// edges are subscribed, see TGpioChipDriver::TryListenLine.)
+class TDebounceEdgeTest: public TDebounceTest
+{
+protected:
+    // Drive an edge (cache the new level + stamp its time) and then let the line
+    // settle: the value is committed once it has held DebounceTimeout unchanged.
+    void Settle(const PGpioLine& line, uint8_t level, TTimePoint edgeTs)
+    {
+        HandleGpioEvent(line, level, edgeTs);
+        line->UpdateIfStable(edgeTs + std::chrono::microseconds(debounceTimeoutUs + 1));
+    }
+};
+
+TEST_F(TDebounceEdgeTest, rising_counts_held_pulse)
+{
+    fakeGpioLineConfig.InterruptEdge = EGpioEdge::RISING;
+    auto now = std::chrono::steady_clock::now();
+    const auto line = std::make_shared<TGpioLine>(fakeGpioLineConfig);
+    InitGpioLine(line, 0); // rest low
+
+    Settle(line, 1, now);                                          // rises and holds -> one count
+    ASSERT_EQ(line->GetCounter()->GetTotal(), 1);
+
+    Settle(line, 0, now + std::chrono::microseconds(1000000));     // returns low: not a rising edge
+    ASSERT_EQ(line->GetCounter()->GetTotal(), 1);
+}
+
+TEST_F(TDebounceEdgeTest, rising_ignores_short_spike_caught_high)
+{
+    fakeGpioLineConfig.InterruptEdge = EGpioEdge::RISING;
+    auto now = std::chrono::steady_clock::now();
+    const auto line = std::make_shared<TGpioLine>(fakeGpioLineConfig);
+    InitGpioLine(line, 0); // rest low
+
+    // Spike: rises (read high), then returns low well within the debounce window.
+    HandleGpioEvent(line, 1, now);
+    auto tReturn = now + std::chrono::microseconds(debounceTimeoutUs / 2);
+    HandleGpioEvent(line, 0, tReturn);
+
+    // Once settled the level equals rest -> no transition -> no count.
+    ASSERT_TRUE(line->UpdateIfStable(tReturn + std::chrono::microseconds(debounceTimeoutUs + 1)));
+    ASSERT_EQ(line->GetCounter()->GetTotal(), 0);
+}
+
+TEST_F(TDebounceEdgeTest, rising_ignores_falling_edge_bounce)
+{
+    fakeGpioLineConfig.InterruptEdge = EGpioEdge::RISING;
+    auto now = std::chrono::steady_clock::now();
+    const auto line = std::make_shared<TGpioLine>(fakeGpioLineConfig);
+    InitGpioLine(line, 0);
+
+    Settle(line, 1, now); // a real pulse
+    ASSERT_EQ(line->GetCounter()->GetTotal(), 1);
+
+    // Pulse ends with contact bounce on the falling edge: 1->0->1->0 within a
+    // short window. The spurious rising sub-edge must not add a second count.
+    auto t = now + std::chrono::microseconds(1000000);
+    HandleGpioEvent(line, 0, t);
+    HandleGpioEvent(line, 1, t + std::chrono::microseconds(50));
+    HandleGpioEvent(line, 0, t + std::chrono::microseconds(100));
+    ASSERT_TRUE(line->UpdateIfStable(t + std::chrono::microseconds(100 + debounceTimeoutUs + 1)));
+    ASSERT_EQ(line->GetCounter()->GetTotal(), 1);
+}
+
+TEST_F(TDebounceEdgeTest, falling_counts_held_pulse)
+{
+    fakeGpioLineConfig.InterruptEdge = EGpioEdge::FALLING;
+    auto now = std::chrono::steady_clock::now();
+    const auto line = std::make_shared<TGpioLine>(fakeGpioLineConfig);
+    InitGpioLine(line, 1); // rest high
+
+    Settle(line, 0, now);                                         // drops and holds -> one count
+    ASSERT_EQ(line->GetCounter()->GetTotal(), 1);
+
+    Settle(line, 1, now + std::chrono::microseconds(1000000));    // returns high: not a falling edge
+    ASSERT_EQ(line->GetCounter()->GetTotal(), 1);
+}
+
+TEST_F(TDebounceEdgeTest, falling_ignores_short_spike_caught_low)
+{
+    fakeGpioLineConfig.InterruptEdge = EGpioEdge::FALLING;
+    auto now = std::chrono::steady_clock::now();
+    const auto line = std::make_shared<TGpioLine>(fakeGpioLineConfig);
+    InitGpioLine(line, 1); // rest high
+
+    HandleGpioEvent(line, 0, now); // dips low (read low)
+    auto tReturn = now + std::chrono::microseconds(debounceTimeoutUs / 2);
+    HandleGpioEvent(line, 1, tReturn); // returns high before debounce elapses
+
+    ASSERT_TRUE(line->UpdateIfStable(tReturn + std::chrono::microseconds(debounceTimeoutUs + 1)));
+    ASSERT_EQ(line->GetCounter()->GetTotal(), 0);
 }


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Исправил обработку фильтрации дребезга. Теперь фронт или спад считаются только, если уровень держался дольше заданной величины.
Раньше не фильтровались короткие всплески, если вход был настроен на подсчёт тольок фронтов или спадов. Код не видел обратный переход и считал, что сигнал не меняется.
Теперь анализируем оба фронта и решаем, что же произошло

___________________________________
**Что поменялось для пользователей:**


___________________________________
**Как проверял/а:**


