### PR TITLE
Add mosquitto dependency

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-mqtt-gpio (2.18.1) stable; urgency=medium
+
+  * Remove obsolete wb-modules.service dependency
+  * Add mosquitto.service dependency to ensure that mosquitto is started before wb-mqtt-gpio
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Fri, 19 Jun 2026 11:06:00 +0500
+
 wb-mqtt-gpio (2.18.0) stable; urgency=medium
 
   * Fix phantom counter increments on idle inputs: a pulse is now counted only

--- a/debian/wb-mqtt-gpio.service
+++ b/debian/wb-mqtt-gpio.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=MQTT Driver for GPIO-controlled switches
 Wants=wb-hwconf-manager.service wb-modules.service
-After=network.target wb-hwconf-manager.service wb-modules.service
+After=network.target wb-hwconf-manager.service mosquitto.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
  * Remove obsolete wb-modules.service dependency
  * Add mosquitto.service dependency to ensure that mosquitto is started before wb-mqtt-gpio

___________________________________
**Что происходит; кому и зачем нужно:**


___________________________________
**Что поменялось для пользователей:**


___________________________________
**Как проверял/а:**


